### PR TITLE
Lumo 2.0: model tiers (Lite/Max) + thinking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ lumo-tamer is a lightweight local proxy that talks to Proton's Lumo API using th
 ## Features
 
 - OpenAI-compatible API server with experimental tool support.
+- Select the Lumo 2.0 model tier (Lite/Max) and thinking mode per request, via the OpenAI `model` and `reasoning_effort` fields.
 - Interactive CLI, let Lumo help you execute commands, read, create and edit files.
 - Sync your conversations with Proton to access them on https://lumo.proton.me or in mobile apps.
 
@@ -195,6 +196,31 @@ server:
 cli:
   enableWebSearch: true
 ```
+
+### Model Tiers and Thinking Mode
+
+lumo-tamer maps standard OpenAI request fields to Lumo 2.0's model tier and answer mode:
+
+- `model`: `lumo` (Proton auto-routes), `lumo-lite`, or `lumo-max`. These are advertised on `/v1/models`; an unknown model returns HTTP 400.
+- `reasoning_effort`: `high` (also `low`/`medium`) turns on thinking mode, `none` turns it off. In the Responses API, use `reasoning.effort` instead.
+
+Defaults and surfacing are configurable:
+
+```yaml
+server:
+  # Tier used when a request omits the model field: auto, lumo-lite, lumo-max
+  defaultModelTier: "auto"
+  # Models advertised on /v1/models and accepted in the model field
+  allowedModels: ["lumo", "lumo-lite", "lumo-max"]
+  reasoning:
+    # Used when a request omits reasoning_effort: "none" or "high"
+    default: "none"
+    # Forward Lumo's thinking tokens as delta.reasoning_content (streaming)
+    # or message.reasoning_content (non-streaming)
+    surfaceThinking: false
+```
+
+> **Note:** Availability of `lumo-max` and thinking mode depends on your Proton plan. Requests are end-to-end encrypted the same way as the rest of lumo-tamer.
 
 ### Instructions
 

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -104,10 +104,10 @@ server:
 
   # Model tier selection (Lumo 2.0).
   # The inbound OpenAI "model" field picks the tier:
-  #   lumo / auto -> Proton routes automatically
-  #   lumo-lite   -> Lumo 2.0 Lite (fast, everyday)
-  #   lumo-max    -> Lumo 2.0 Max (high-performance)
-  # Tier used when a request omits the model field:
+  #   lumo      -> Proton routes automatically
+  #   lumo-lite -> Lumo 2.0 Lite (fast, everyday)
+  #   lumo-max  -> Lumo 2.0 Max (high-performance)
+  # Tier used when a request omits the model field (auto = lumo / Proton routes):
   defaultModelTier: "auto"
   # Models advertised on /v1/models and accepted in the "model" field.
   # Unknown models are rejected with HTTP 400.

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -99,7 +99,31 @@ commands:
 server:
   port: 3003
   apiKey: "your-secret-api-key-here"
+  # Model echoed back when a request omits the model field.
   apiModelName: "lumo"
+
+  # Model tier selection (Lumo 2.0).
+  # The inbound OpenAI "model" field picks the tier:
+  #   lumo / auto -> Proton routes automatically
+  #   lumo-lite   -> Lumo 2.0 Lite (fast, everyday)
+  #   lumo-max    -> Lumo 2.0 Max (high-performance)
+  # Tier used when a request omits the model field:
+  defaultModelTier: "auto"
+  # Models advertised on /v1/models and accepted in the "model" field.
+  # Unknown models are rejected with HTTP 400.
+  allowedModels:
+    - "lumo"
+    - "lumo-lite"
+    - "lumo-max"
+
+  # Thinking / reasoning mode (Lumo 2.0).
+  reasoning:
+    # Used when the client does not send reasoning_effort. "none" or "high".
+    # (Inbound reasoning_effort low/medium/high all map to high.)
+    default: "none"
+    # Forward Lumo's thinking tokens to the client as delta.reasoning_content
+    # (streaming) or message.reasoning_content (non-streaming).
+    surfaceThinking: false
 
   # Max request body size
   # Increase if clients send larger tool/context payloads, but be aware:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumo-tamer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumo-tamer",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "GPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4321,8 +4321,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-saga": {
       "version": "1.4.2",
@@ -5138,7 +5137,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5431,7 +5429,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5540,7 +5537,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5554,7 +5550,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5744,7 +5739,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5760,7 +5754,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/api/routes/chat-completions/events.ts
+++ b/src/api/routes/chat-completions/events.ts
@@ -27,6 +27,18 @@ export class ChatCompletionEventEmitter {
     this.res.write(`data: ${JSON.stringify(chunk)}\n\n`);
   }
 
+  emitReasoningDelta(reasoning: string): void {
+    if (!reasoning) return;
+    const chunk: OpenAIStreamChunk = {
+      id: this.id,
+      object: 'chat.completion.chunk',
+      created: this.created,
+      model: this.model,
+      choices: [{ index: 0, delta: { reasoning_content: reasoning }, finish_reason: null }],
+    };
+    this.res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  }
+
   emitToolCallDelta(callId: string, name: string, args: Record<string, unknown>): void {
     const chunk: OpenAIStreamChunk = {
       id: this.id,

--- a/src/api/routes/chat-completions/index.ts
+++ b/src/api/routes/chat-completions/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { EndpointDependencies, OpenAIChatRequest, OpenAIChatResponse } from '../../types.js';
 import { getServerConfig, getConversationsConfig, getLogConfig, getServerInstructionsConfig, getReasoningConfig } from '../../../app/config.js';
-import { modelToTier, normalizeModelId, isModelAllowed, resolveReasoning } from '../../../lumo-client/model-tier.js';
+import { modelToTier, normalizeModelId, isModelAllowed, resolveReasoning, isValidReasoningEffort } from '../../../lumo-client/model-tier.js';
 import type { LumoModelTier } from '../../../lumo-client/types.js';
 import { logger } from '../../../app/logger.js';
 import { convertOpenAIChatMessages, extractSystemMessage } from '../../message-converter.js';
@@ -81,17 +81,25 @@ export function createChatCompletionsRouter(deps: EndpointDependencies): Router 
         return sendInvalidRequest(res, 'At least one user message is required', 'messages', 'missing_user_message');
       }
 
-      // Validate the requested model before any side effects (persistence, SSE, queue).
-      if (request.model) {
+      // Validate model + reasoning_effort before any side effects (persistence, SSE, queue).
+      if (request.model !== undefined && request.model !== null) {
         const allowedModels = getServerConfig().allowedModels;
-        if (!isModelAllowed(normalizeModelId(request.model), allowedModels)) {
+        if (typeof request.model !== 'string' || !isModelAllowed(normalizeModelId(request.model), allowedModels)) {
           return sendInvalidRequest(
             res,
-            `Unknown model '${request.model}'. Allowed models: ${allowedModels.join(', ')}`,
+            `Unknown model '${String(request.model)}'. Allowed models: ${allowedModels.join(', ')}`,
             'model',
             'model_not_found',
           );
         }
+      }
+      if (!isValidReasoningEffort(request.reasoning_effort)) {
+        return sendInvalidRequest(
+          res,
+          `Invalid reasoning_effort '${String(request.reasoning_effort)}'. Allowed: none, low, medium, high`,
+          'reasoning_effort',
+          'invalid_reasoning_effort',
+        );
       }
 
       // ===== Generate conversation ID for persistence =====

--- a/src/api/routes/chat-completions/index.ts
+++ b/src/api/routes/chat-completions/index.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { EndpointDependencies, OpenAIChatRequest, OpenAIChatResponse } from '../../types.js';
-import { getServerConfig, getConversationsConfig, getLogConfig, getServerInstructionsConfig } from '../../../app/config.js';
+import { getServerConfig, getConversationsConfig, getLogConfig, getServerInstructionsConfig, getReasoningConfig } from '../../../app/config.js';
+import { modelToTier, normalizeModelId, isModelAllowed, resolveReasoning } from '../../../lumo-client/model-tier.js';
+import type { LumoModelTier } from '../../../lumo-client/types.js';
 import { logger } from '../../../app/logger.js';
 import { convertOpenAIChatMessages, extractSystemMessage } from '../../message-converter.js';
 import { buildInstructions } from '../../instructions.js';
@@ -79,6 +81,19 @@ export function createChatCompletionsRouter(deps: EndpointDependencies): Router 
         return sendInvalidRequest(res, 'At least one user message is required', 'messages', 'missing_user_message');
       }
 
+      // Validate the requested model before any side effects (persistence, SSE, queue).
+      if (request.model) {
+        const allowedModels = getServerConfig().allowedModels;
+        if (!isModelAllowed(normalizeModelId(request.model), allowedModels)) {
+          return sendInvalidRequest(
+            res,
+            `Unknown model '${request.model}'. Allowed models: ${allowedModels.join(', ')}`,
+            'model',
+            'model_not_found',
+          );
+        }
+      }
+
       // ===== Generate conversation ID for persistence =====
       // Chat Completions has no conversation parameter per OpenAI spec.
       // We use deriveIdFromUser to track conversations for Proton sync.
@@ -140,8 +155,17 @@ async function handleChatRequest(
 ): Promise<void> {
   const id = generateChatCompletionId();
   const created = Math.floor(Date.now() / 1000);
-  const model = request.model || getServerConfig().apiModelName;
+  const serverConfig = getServerConfig();
+  const model = request.model || serverConfig.apiModelName;
   const ctx = buildRequestContext(deps, conversationId, request.tools);
+
+  // Resolve tier (Lite/Max) and thinking mode from the inbound request.
+  const tier: LumoModelTier = request.model
+    ? modelToTier(normalizeModelId(request.model))
+    : serverConfig.defaultModelTier;
+  const reasoningConfig = getReasoningConfig();
+  const enableReasoning = resolveReasoning(request.reasoning_effort, reasoningConfig.default === 'high');
+  const surfaceThinking = reasoningConfig.surfaceThinking;
 
   // Streaming setup
   const emitter = streaming ? new ChatCompletionEventEmitter(res, id, created, model) : null;
@@ -150,6 +174,7 @@ async function handleChatRequest(
   }
 
   let accumulatedText = '';
+  let reasoningContent: string | undefined;
   let toolCalls: typeof processor.toolCallsEmitted | undefined;
 
   const processor = createStreamingToolProcessor(ctx.hasCustomTools, {
@@ -175,10 +200,18 @@ async function handleChatRequest(
           requestTitle: ctx.requestTitle,
           instructions,
           injectInstructionsInto,
+          modelTier: tier,
+          enableReasoning,
+          onReasoning: surfaceThinking && emitter
+            ? (text) => emitter.emitReasoningDelta(text)
+            : undefined,
         })
       );
 
       logger.debug('[Server] Stream completed');
+      if (surfaceThinking && !streaming && result.reasoning) {
+        reasoningContent = result.reasoning;
+      }
       processor.finalize();
       persistTitle(result, deps, conversationId);
       toolCalls = processor.toolCallsEmitted.length > 0 ? processor.toolCallsEmitted : undefined;
@@ -216,6 +249,7 @@ async function handleChatRequest(
             role: 'assistant',
             content: accumulatedText,
             ...(toolCalls ? { tool_calls: toolCalls } : {}),
+            ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
           },
           finish_reason: toolCalls ? 'tool_calls' : 'stop',
         }],

--- a/src/api/routes/models.ts
+++ b/src/api/routes/models.ts
@@ -8,14 +8,12 @@ export function createModelsRouter(): Router {
   router.get('/v1/models', (req: Request, res: Response) => {
     res.json({
       object: 'list',
-      data: [
-        {
-          id: serverConfig.apiModelName,
-          object: 'model',
-          created: Date.now(),
-          owned_by: 'proton',
-        },
-      ],
+      data: serverConfig.allowedModels.map((id) => ({
+        id,
+        object: 'model',
+        created: Date.now(),
+        owned_by: 'proton',
+      })),
     });
   });
 

--- a/src/api/routes/responses/index.ts
+++ b/src/api/routes/responses/index.ts
@@ -4,7 +4,8 @@ import { logger } from '../../../app/logger.js';
 import { handleRequest } from './request-handlers.js';
 import { convertOpenAIResponseMessages } from '../../message-converter.js';
 import { buildInstructions } from '../../instructions.js';
-import { getConversationsConfig, getServerInstructionsConfig } from '../../../app/config.js';
+import { getConversationsConfig, getServerInstructionsConfig, getServerConfig } from '../../../app/config.js';
+import { isModelAllowed, normalizeModelId } from '../../../lumo-client/model-tier.js';
 import { getMetrics } from '../../../app/metrics.js';
 import { trackCustomToolCompletion } from '../../tools/call-id.js';
 import { sendInvalidRequest, sendServerError } from '../../error-handler.js';
@@ -93,6 +94,19 @@ export function createResponsesRouter(deps: EndpointDependencies): Router {
         );
         if (!hasUserMessage) {
           return sendInvalidRequest(res, 'input array must include at least one user message', 'input', 'missing_user_message');
+        }
+      }
+
+      // Validate the requested model before any side effects.
+      if (request.model) {
+        const allowedModels = getServerConfig().allowedModels;
+        if (!isModelAllowed(normalizeModelId(request.model), allowedModels)) {
+          return sendInvalidRequest(
+            res,
+            `Unknown model '${request.model}'. Allowed models: ${allowedModels.join(', ')}`,
+            'model',
+            'model_not_found',
+          );
         }
       }
 

--- a/src/api/routes/responses/index.ts
+++ b/src/api/routes/responses/index.ts
@@ -5,7 +5,7 @@ import { handleRequest } from './request-handlers.js';
 import { convertOpenAIResponseMessages } from '../../message-converter.js';
 import { buildInstructions } from '../../instructions.js';
 import { getConversationsConfig, getServerInstructionsConfig, getServerConfig } from '../../../app/config.js';
-import { isModelAllowed, normalizeModelId } from '../../../lumo-client/model-tier.js';
+import { isModelAllowed, normalizeModelId, isValidReasoningEffort } from '../../../lumo-client/model-tier.js';
 import { getMetrics } from '../../../app/metrics.js';
 import { trackCustomToolCompletion } from '../../tools/call-id.js';
 import { sendInvalidRequest, sendServerError } from '../../error-handler.js';
@@ -97,17 +97,25 @@ export function createResponsesRouter(deps: EndpointDependencies): Router {
         }
       }
 
-      // Validate the requested model before any side effects.
-      if (request.model) {
+      // Validate model + reasoning effort before any side effects.
+      if (request.model !== undefined && request.model !== null) {
         const allowedModels = getServerConfig().allowedModels;
-        if (!isModelAllowed(normalizeModelId(request.model), allowedModels)) {
+        if (typeof request.model !== 'string' || !isModelAllowed(normalizeModelId(request.model), allowedModels)) {
           return sendInvalidRequest(
             res,
-            `Unknown model '${request.model}'. Allowed models: ${allowedModels.join(', ')}`,
+            `Unknown model '${String(request.model)}'. Allowed models: ${allowedModels.join(', ')}`,
             'model',
             'model_not_found',
           );
         }
+      }
+      if (!isValidReasoningEffort(request.reasoning?.effort)) {
+        return sendInvalidRequest(
+          res,
+          `Invalid reasoning.effort '${String(request.reasoning?.effort)}'. Allowed: none, low, medium, high`,
+          'reasoning.effort',
+          'invalid_reasoning_effort',
+        );
       }
 
       // ===== STEP 3: Convert input to turns =====

--- a/src/api/routes/responses/request-handlers.ts
+++ b/src/api/routes/responses/request-handlers.ts
@@ -108,7 +108,7 @@ function createCompletedResponse(
     parallel_tool_calls: false,
     previous_response_id: request.previous_response_id ?? null,
     reasoning: {
-      effort: null,
+      effort: request.reasoning?.effort ?? null,
       summary: null,
     },
     store: request.store ?? false,

--- a/src/api/routes/responses/request-handlers.ts
+++ b/src/api/routes/responses/request-handlers.ts
@@ -7,7 +7,9 @@ import {
   MessageOutputItem,
   FunctionCallOutputItem,
 } from '../../types.js';
-import { getServerConfig } from '../../../app/config.js';
+import { getServerConfig, getReasoningConfig } from '../../../app/config.js';
+import { modelToTier, normalizeModelId, resolveReasoning } from '../../../lumo-client/model-tier.js';
+import type { LumoModelTier } from '../../../lumo-client/types.js';
 import { logger } from '../../../app/logger.js';
 import { ResponseEventEmitter } from './events.js';
 import type { Turn } from '../../../lumo-client/index.js';
@@ -141,8 +143,15 @@ export async function handleRequest(
   const id = generateResponseId();
   const itemId = generateItemId();
   const createdAt = Math.floor(Date.now() / 1000);
-  const model = request.model || getServerConfig().apiModelName;
+  const serverConfig = getServerConfig();
+  const model = request.model || serverConfig.apiModelName;
   const ctx = buildRequestContext(deps, conversationId, request.tools);
+
+  // Resolve tier (Lite/Max) and thinking mode from the inbound request.
+  const tier: LumoModelTier = request.model
+    ? modelToTier(normalizeModelId(request.model))
+    : serverConfig.defaultModelTier;
+  const enableReasoning = resolveReasoning(request.reasoning?.effort, getReasoningConfig().default === 'high');
 
   // Streaming setup
   const emitter = streaming ? new ResponseEventEmitter(res) : null;
@@ -186,6 +195,8 @@ export async function handleRequest(
           requestTitle: ctx.requestTitle,
           instructions,
           injectInstructionsInto,
+          modelTier: tier,
+          enableReasoning,
         })
       );
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -66,6 +66,8 @@ export interface OpenAIChatRequest {
   stream?: boolean;
   temperature?: number;
   max_tokens?: number;
+  // Thinking mode: 'none' disables; 'low'/'medium'/'high' enable reasoning.
+  reasoning_effort?: 'none' | 'low' | 'medium' | 'high' | null;
   tools?: OpenAITool[];
   user?: string;
   // Custom extension for conversation persistence
@@ -77,6 +79,8 @@ export interface ChatMessageWithTools {
   role: 'assistant';
   content: string | null;
   tool_calls?: OpenAIToolCall[];
+  // Thinking/reasoning text (when surfaceThinking is enabled).
+  reasoning_content?: string;
 }
 
 export interface OpenAIChatResponse {
@@ -111,6 +115,8 @@ export interface StreamingToolCallDelta {
 export interface StreamingDelta {
   role?: 'assistant';
   content?: string;
+  // Thinking/reasoning text (when surfaceThinking is enabled).
+  reasoning_content?: string;
   tool_calls?: StreamingToolCallDelta[];
 }
 
@@ -141,6 +147,8 @@ export interface OpenAIResponseRequest {
   model?: string;
   input?: string | Array<OpenAIResponseMessage>;
   instructions?: string;
+  // Thinking mode (Responses API places effort under reasoning.effort).
+  reasoning?: { effort?: 'none' | 'low' | 'medium' | 'high' | null };
   stream?: boolean;
   temperature?: number;
   max_output_tokens?: number;

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -127,6 +127,12 @@ const serverMergedConfigSchema = z.object({
   port: z.number().int().positive(),
   apiKey: z.string().min(1, 'server.apiKey is required'),
   apiModelName: z.string().min(1),
+  defaultModelTier: z.enum(['auto', 'lumo-lite', 'lumo-max']),
+  allowedModels: z.array(z.string().min(1)).min(1),
+  reasoning: z.object({
+    default: z.enum(['none', 'high']),
+    surfaceThinking: z.boolean(),
+  }),
 });
 
 // CLI merged config schema
@@ -245,6 +251,11 @@ export function getServerInstructionsConfig() {
 export function getMetricsConfig() {
   const cfg = getServerConfig();
   return cfg.metrics;
+}
+
+export function getReasoningConfig() {
+  const cfg = getServerConfig();
+  return cfg.reasoning;
 }
 
 // CLI-specific getters

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 import merge from 'lodash/merge.js';
+import mergeWith from 'lodash/mergeWith.js';
+
+/**
+ * Merge config layers, but REPLACE arrays wholesale instead of merging them by
+ * index. Index-wise array merge means a user override like
+ * `allowedModels: ["lumo-max"]` would leave the other defaults in place; config
+ * arrays should fully replace the default.
+ */
+function mergeConfigLayers(...sources: unknown[]): Record<string, unknown> {
+  return mergeWith({}, ...sources, (_objValue: unknown, srcValue: unknown) =>
+    Array.isArray(srcValue) ? srcValue : undefined,
+  );
+}
 import bytes from 'bytes';
 import { fatalExit, loadConfigYaml, loadDefaultsYaml } from './config-file.js';
 
@@ -173,12 +186,12 @@ function loadMergedConfig(mode: ConfigMode): MergedConfig {
     const userModeConfig = (mode === 'server' ? userConfig.server : userConfig.cli) as Record<string, unknown> | undefined;
 
     // Stage 1: defaults -> user (for all keys including mode-specific)
-    const merged = merge({}, configDefaults, defaultModeConfig, userConfig, userModeConfig);
+    const merged = mergeConfigLayers(configDefaults, defaultModeConfig, userConfig, userModeConfig);
 
     // Stage 2: apply user mode overrides for shared keys only
     for (const key of SHARED_KEYS) {
       if (userModeConfig?.[key]) {
-        merged[key] = merge({}, merged[key], userModeConfig[key]);
+        merged[key] = mergeConfigLayers(merged[key], userModeConfig[key]);
       }
     }
 

--- a/src/auth/api-factory.ts
+++ b/src/auth/api-factory.ts
@@ -4,7 +4,7 @@
  * Supports automatic 401 retry with token refresh via onAuthError callback.
  */
 
-import type { ProtonApi, ProtonApiOptions } from '../lumo-client/types.js';
+import type { ProtonApi, ProtonApiError, ProtonApiOptions } from '../lumo-client/types.js';
 import { APP_VERSION_HEADER } from '@lumo/config.js';
 import { PROTON_URLS } from '../app/urls.js';
 import { logger } from '../app/logger.js';
@@ -130,18 +130,23 @@ export function createProtonApi(options: ApiFactoryOptions): ProtonApi {
             // Try to extract Proton's error message from JSON response
             let protonError: string | undefined;
             let protonCode: number | undefined;
+            let parsedBody: unknown;
             try {
-                const parsed = JSON.parse(errorBody);
-                protonError = parsed.Error;
-                protonCode = parsed.Code;
+                parsedBody = JSON.parse(errorBody);
+                protonError = (parsedBody as { Error?: string }).Error;
+                protonCode = (parsedBody as { Code?: number }).Code;
             } catch { /* not JSON */ }
 
             const error = new Error(
                 protonError
                     || `API error: ${response.status} ${response.statusText}`
             );
-            (error as any).status = response.status;
-            (error as any).Code = protonCode;
+            // Preserve full error context so callers (e.g. the chat/completions
+            // terminal-error decoder) can inspect the Proton response body.
+            (error as ProtonApiError).status = response.status;
+            (error as ProtonApiError).Code = protonCode;
+            (error as ProtonApiError).data = parsedBody;
+            (error as ProtonApiError).body = errorBody;
             throw error;
         }
 

--- a/src/lumo-client/client.ts
+++ b/src/lumo-client/client.ts
@@ -118,15 +118,18 @@ export class LumoClient {
         let usage: LumoUsage | undefined;
         let suppressChunks = false;
         let abortEarly = false;
+        let streamEnded = false;
 
-        const decrypt = async (text: string, encrypted?: boolean): Promise<string> => {
+        // Decrypt an encrypted chunk. On failure, return null so the caller drops
+        // the chunk (matching Proton's client) rather than emitting ciphertext.
+        const decrypt = async (text: string, encrypted?: boolean): Promise<string | null> => {
             if (encrypted && encryptionContext) {
                 const adString = `lumo.response.${encryptionContext.requestId}.chunk`;
                 try {
                     return await decryptString(text, encryptionContext.requestKey, adString);
                 } catch (error) {
-                    logger.error({ error }, 'Failed to decrypt chunk');
-                    return text;
+                    logger.error({ error }, 'Failed to decrypt chunk; dropping');
+                    return null;
                 }
             }
             return text;
@@ -137,16 +140,18 @@ export class LumoClient {
                 case 'token_data': {
                     if (msg.target === 'message') {
                         const text = await decrypt(msg.content, msg.encrypted);
+                        if (text === null) break;
                         content += text;
                         if (!suppressChunks) {
                             opts.onChunk?.(text);
                         }
                     } else if (msg.target === 'reasoning') {
                         const text = await decrypt(msg.content, msg.encrypted);
+                        if (text === null) break;
                         reasoning += text;
                         opts.onReasoning?.(text);
                     } else if (msg.target === 'tool_call') {
-                        // Streamed OpenAI tool-call deltas (custom-tool misroute path).
+                        // Complete tool call (custom-tool misroute path); emitted by finalize().
                         if (nativeToolProcessor.feedToolCall(msg.content)) {
                             suppressChunks = true;
                             abortEarly = true;
@@ -157,6 +162,7 @@ export class LumoClient {
                 case 'server_tool_call': {
                     // Native tool call (e.g. proton_info); normalize into the tool processor.
                     const args = msg.arguments !== undefined ? await decrypt(msg.arguments, msg.encrypted) : '';
+                    if (args === null) break;
                     let parsedArgs: unknown = {};
                     try {
                         parsedArgs = args ? JSON.parse(args) : {};
@@ -172,6 +178,7 @@ export class LumoClient {
                 }
                 case 'server_tool_result': {
                     const result = await decrypt(msg.content, msg.encrypted);
+                    if (result === null) break;
                     nativeToolProcessor.feedToolResult(result);
                     break;
                 }
@@ -191,14 +198,17 @@ export class LumoClient {
         try {
             while (true) {
                 const { done, value } = await reader.read();
-                if (done) break;
+                if (done) {
+                    streamEnded = true;
+                    break;
+                }
                 const chunk = decoder.decode(value, { stream: true });
                 for (const msg of processor.processChunk(chunk)) {
                     await processMessage(msg);
                 }
                 if (abortEarly) break;
             }
-            // Flush the decoder and any trailing buffered line.
+            // Flush the decoder and any trailing buffered line + accumulated tool calls.
             const tail = decoder.decode();
             if (tail) {
                 for (const msg of processor.processChunk(tail)) {
@@ -212,7 +222,19 @@ export class LumoClient {
             nativeToolProcessor.finalize();
             return { content, reasoning, usage, native: nativeToolProcessor.getResult() };
         } finally {
-            reader.releaseLock();
+            // Cancel the upstream body if we stopped early (e.g. misrouted-tool abort).
+            if (!streamEnded) {
+                try {
+                    await reader.cancel();
+                } catch {
+                    // ignore
+                }
+            }
+            try {
+                reader.releaseLock();
+            } catch {
+                // ignore
+            }
         }
     }
 
@@ -314,7 +336,8 @@ export class LumoClient {
             : turns;
 
         // Title generation is a separate, concurrent, non-fatal completion.
-        const titlePromise = requestTitle
+        // Only at the top level: a bounce must not launch its own title request.
+        const titlePromise = requestTitle && !isBounce
             ? this.runCompletion(turns, {
                 endpoint,
                 tier: modelTier,
@@ -359,7 +382,13 @@ export class LumoClient {
                 { role: Role.User, content: bounceInstruction },
             ];
 
-            return this.chatWithHistory(bounceTurns, onChunk, options, true);
+            // The bounce runs with isBounce=true (no title of its own); carry the
+            // title from this top-level attempt so it isn't wasted or re-derived
+            // from the synthetic bounce transcript.
+            const bounced = await this.chatWithHistory(bounceTurns, onChunk, options, true);
+            const titleResult = titlePromise ? await titlePromise : null;
+            const title = titleResult?.content ? postProcessTitle(titleResult.content) : bounced.title;
+            return { ...bounced, title };
         }
 
         // Build message data for persistence.

--- a/src/lumo-client/client.ts
+++ b/src/lumo-client/client.ts
@@ -1,6 +1,9 @@
 /**
- * Simple Lumo API client
- * Minimal implementation with U2L encryption support
+ * Lumo API client (Lumo 2.0).
+ *
+ * Talks to Proton's unified `ai/v1/chat/completions` endpoint with optional U2L
+ * encryption, streams the OpenAI-style SSE response, surfaces reasoning/thinking,
+ * detects native tool calls, and bounces misrouted custom tools.
  */
 
 import { decryptString } from '@lumo/crypto/index.js';
@@ -13,25 +16,26 @@ import {
     generateRequestKey,
     RequestEncryptionParams,
 } from '@lumo/lib/lumo-api-client/core/encryptionParams.js';
-import { StreamProcessor } from '@lumo/lib/lumo-api-client/core/streaming.js';
 import { logger } from '../app/logger.js';
 import {
     Role,
     type AesGcmCryptoKey,
     type ProtonApi,
-    type GenerationResponseMessage,
-    type LumoApiGenerationRequest,
     type RequestId,
     type ToolName,
     type Turn,
     type ParsedToolCall,
     type AssistantMessageData,
     type LumoClientOptions,
+    type LumoModelTier,
+    type LumoUsage,
     type ChatResult,
 } from './types.js';
+import { buildChatCompletionsBody, LUMO_CHAT_ENDPOINT, type LumoCompletionTarget } from './v2-body.js';
+import { V2StreamProcessor } from './v2-stream.js';
 import { getInstructionsConfig, getLogConfig, getConfigMode, getCustomToolsConfig, getEnableWebSearch } from '../app/config.js';
 import { injectInstructionsIntoTurns } from './instructions.js';
-import { NativeToolCallProcessor } from '../api/tools/native-tool-call-processor.js';
+import { NativeToolCallProcessor, type NativeToolCallResult } from '../api/tools/native-tool-call-processor.js';
 import { postProcessTitle } from '@lumo/lib/lumo-api-client/utils.js';
 
 // Re-export types for external consumers
@@ -39,7 +43,20 @@ export type { LumoClientOptions, ChatResult };
 
 const DEFAULT_INTERNAL_TOOLS: ToolName[] = ['proton_info'];
 const DEFAULT_EXTERNAL_TOOLS: ToolName[] = ['web_search', 'weather', 'stock', 'cryptocurrency'];
-const DEFAULT_ENDPOINT = 'ai/v1/chat';
+
+/** Encryption context for decrypting a response stream. */
+interface EncryptionContext {
+    requestKey: AesGcmCryptoKey;
+    requestId: RequestId;
+}
+
+/** Raw result of a single chat/completions request. */
+interface CompletionResult {
+    content: string;
+    reasoning: string;
+    usage?: LumoUsage;
+    native: NativeToolCallResult;
+}
 
 /** Build the bounce instruction: config text + the misrouted tool call as JSON example.
  *  Includes the prefix in the example JSON so Lumo outputs it correctly. */
@@ -68,97 +85,106 @@ export class LumoClient {
 
     /**
      * Send a message and stream the response
-     * @param message - User message
-     * @param onChunk - Optional callback for each text chunk
-     * @param options - Request options
-     * @returns ChatResult with response text and optional title
      */
     async chat(
         message: string,
         onChunk?: (content: string) => void,
         options: LumoClientOptions = {}
     ): Promise<ChatResult> {
-
         const turns: Turn[] = [{ role: Role.User, content: message }];
         return this.chatWithHistory(turns, onChunk, options);
-
     }
 
     /**
-     * Process SSE stream and extract response text and optional title
-     *
-     * Title generation inspired by WebClients redux.ts lines 49-110
+     * Process the OpenAI-style SSE stream: decrypt content/reasoning, drain
+     * reasoning to its sink, feed native tool calls/results, capture usage.
      */
     private async processStream(
         stream: ReadableStream<Uint8Array>,
-        onChunk?: (content: string) => void,
-        encryptionContext?: {
-            enableEncryption: boolean;
-            requestKey?: AesGcmCryptoKey;
-            requestId?: RequestId;
+        encryptionContext: EncryptionContext | undefined,
+        opts: {
+            onChunk?: (content: string) => void;
+            onReasoning?: (content: string) => void;
+            isBounce: boolean;
         },
-        /** When true, ignore misrouted tool calls (they're stale leftovers in bounce responses). */
-        isBounce = false,
-    ): Promise<ChatResult> {
+    ): Promise<CompletionResult> {
         const reader = stream.getReader();
         const decoder = new TextDecoder('utf-8');
-        const processor = new StreamProcessor();
-        let fullResponse = '';
-        let fullTitle = '';
+        const processor = new V2StreamProcessor();
+        const nativeToolProcessor = new NativeToolCallProcessor(opts.isBounce);
 
-        // Native tool call processing (SSE tool_call/tool_result targets)
-        const nativeToolProcessor = new NativeToolCallProcessor(isBounce);
+        let content = '';
+        let reasoning = '';
+        let usage: LumoUsage | undefined;
         let suppressChunks = false;
         let abortEarly = false;
 
-        const processMessage = async (msg: GenerationResponseMessage) => {
-            if (msg.type === 'token_data') {
-                let content = msg.content;
-
-                // Decrypt if needed
-                if (
-                    msg.encrypted &&
-                    encryptionContext?.enableEncryption &&
-                    encryptionContext.requestKey &&
-                    encryptionContext.requestId
-                ) {
-                    const adString = `lumo.response.${encryptionContext.requestId}.chunk`;
-                    try {
-                        content = await decryptString(
-                            content,
-                            encryptionContext.requestKey,
-                            adString
-                        );
-                    } catch (error) {
-                        logger.error(error, 'Failed to decrypt chunk:');
-                        // Continue with encrypted content
-                    }
+        const decrypt = async (text: string, encrypted?: boolean): Promise<string> => {
+            if (encrypted && encryptionContext) {
+                const adString = `lumo.response.${encryptionContext.requestId}.chunk`;
+                try {
+                    return await decryptString(text, encryptionContext.requestKey, adString);
+                } catch (error) {
+                    logger.error({ error }, 'Failed to decrypt chunk');
+                    return text;
                 }
+            }
+            return text;
+        };
 
-                if (msg.target === 'message') {
-                    fullResponse += content;
-                    if (!suppressChunks) {
-                        onChunk?.(content);
+        const processMessage = async (msg: ReturnType<V2StreamProcessor['processChunk']>[number]) => {
+            switch (msg.type) {
+                case 'token_data': {
+                    if (msg.target === 'message') {
+                        const text = await decrypt(msg.content, msg.encrypted);
+                        content += text;
+                        if (!suppressChunks) {
+                            opts.onChunk?.(text);
+                        }
+                    } else if (msg.target === 'reasoning') {
+                        const text = await decrypt(msg.content, msg.encrypted);
+                        reasoning += text;
+                        opts.onReasoning?.(text);
+                    } else if (msg.target === 'tool_call') {
+                        // Streamed OpenAI tool-call deltas (custom-tool misroute path).
+                        if (nativeToolProcessor.feedToolCall(msg.content)) {
+                            suppressChunks = true;
+                            abortEarly = true;
+                        }
                     }
-                } else if (msg.target === 'title') {
-                    // Accumulate title chunks (title streams before message)
-                    fullTitle += content;
-                } else if (msg.target === 'tool_call') {
-                    if (nativeToolProcessor.feedToolCall(content)) {
+                    break;
+                }
+                case 'server_tool_call': {
+                    // Native tool call (e.g. proton_info); normalize into the tool processor.
+                    const args = msg.arguments !== undefined ? await decrypt(msg.arguments, msg.encrypted) : '';
+                    let parsedArgs: unknown = {};
+                    try {
+                        parsedArgs = args ? JSON.parse(args) : {};
+                    } catch {
+                        parsedArgs = args;
+                    }
+                    const json = JSON.stringify({ name: msg.name, arguments: parsedArgs });
+                    if (nativeToolProcessor.feedToolCall(json)) {
                         suppressChunks = true;
                         abortEarly = true;
                     }
-                } else if (msg.target === 'tool_result') {
-                    nativeToolProcessor.feedToolResult(content);
+                    break;
                 }
-            } else if (
-                msg.type === 'error' ||
-                msg.type === 'rejected' ||
-                msg.type === 'harmful' ||
-                msg.type === 'timeout'
-            ) {
-                const detail = (msg as any).message;
-                throw new Error(`API returned ${msg.type}${detail ? `: ${detail}` : ''}`);
+                case 'server_tool_result': {
+                    const result = await decrypt(msg.content, msg.encrypted);
+                    nativeToolProcessor.feedToolResult(result);
+                    break;
+                }
+                case 'usage':
+                    usage = msg.usage;
+                    break;
+                case 'harmful':
+                    throw new Error('API returned harmful');
+                case 'error':
+                    throw new Error(`API returned error${msg.message ? `: ${msg.message}` : ''}`);
+                case 'done':
+                    abortEarly = true;
+                    break;
             }
         };
 
@@ -166,56 +192,88 @@ export class LumoClient {
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
-
                 const chunk = decoder.decode(value, { stream: true });
-                const messages = processor.processChunk(chunk);
-
-                for (const msg of messages) {
+                for (const msg of processor.processChunk(chunk)) {
                     await processMessage(msg);
                 }
                 if (abortEarly) break;
             }
-
-            // Process any remaining data
-            const finalMessages = processor.finalize();
-            for (const msg of finalMessages) {
+            // Flush the decoder and any trailing buffered line.
+            const tail = decoder.decode();
+            if (tail) {
+                for (const msg of processor.processChunk(tail)) {
+                    await processMessage(msg);
+                }
+            }
+            for (const msg of processor.finalize()) {
                 await processMessage(msg);
             }
 
-            // Finalize tracking and get result
             nativeToolProcessor.finalize();
-            const nativeResult = nativeToolProcessor.getResult();
-
-            // Build message data for persistence
-            // Only include native tool data if not misrouted (misrouted calls are bounced)
-            const message: AssistantMessageData = { content: fullResponse };
-            if (nativeResult.toolCall && !nativeResult.misrouted) {
-                message.toolCall = JSON.stringify({
-                    name: nativeResult.toolCall.name,
-                    arguments: nativeResult.toolCall.arguments,
-                });
-                if (nativeResult.toolResult) {
-                    message.toolResult = nativeResult.toolResult;
-                }
-            }
-
-            return {
-                message,
-                title: fullTitle || undefined,
-                nativeToolCallFailed: nativeResult.toolCall ? nativeResult.failed : undefined,
-                misrouted: nativeResult.misrouted,
-                // Keep parsed tool call for bounce handling (internal use only)
-                _nativeToolCallForBounce: nativeResult.misrouted ? nativeResult.toolCall : undefined,
-            };
+            return { content, reasoning, usage, native: nativeToolProcessor.getResult() };
         } finally {
             reader.releaseLock();
         }
     }
 
+    /** Encrypt (optionally), build the body, POST, and process one completion. */
+    private async runCompletion(
+        turns: Turn[],
+        params: {
+            endpoint: string;
+            tier: LumoModelTier;
+            enableReasoning: boolean;
+            tools: ToolName[];
+            enableEncryption: boolean;
+            target: LumoCompletionTarget;
+            onChunk?: (content: string) => void;
+            onReasoning?: (content: string) => void;
+            isBounce: boolean;
+        },
+    ): Promise<CompletionResult> {
+        let processedTurns = turns;
+        let encryption: { requestKeyEncB64: string; requestId: string } | undefined;
+        let encryptionContext: EncryptionContext | undefined;
+
+        if (params.enableEncryption) {
+            const requestKey = await generateRequestKey();
+            const requestId = generateRequestId();
+            const encryptionParams = new RequestEncryptionParams(requestKey, requestId);
+            const requestKeyEncB64 = await encryptionParams.encryptRequestKey(DEFAULT_LUMO_PUB_KEY);
+            processedTurns = await encryptTurns(turns, encryptionParams);
+            encryption = { requestKeyEncB64, requestId: encryptionParams.requestId };
+            encryptionContext = { requestKey: encryptionParams.requestKey, requestId: encryptionParams.requestId };
+        }
+
+        const body = buildChatCompletionsBody({
+            turns: processedTurns,
+            tier: params.tier,
+            enableReasoning: params.enableReasoning,
+            tools: params.tools,
+            encryption,
+            encrypted: params.enableEncryption,
+            target: params.target,
+        });
+
+        const stream = (await this.protonApi({
+            url: params.endpoint,
+            method: 'post',
+            data: body,
+            output: 'stream',
+        })) as ReadableStream<Uint8Array>;
+
+        return this.processStream(stream, encryptionContext, {
+            onChunk: params.onChunk,
+            onReasoning: params.onReasoning,
+            isBounce: params.isBounce,
+        });
+    }
+
     /**
-     * Multi-turn conversation support
+     * Multi-turn conversation support.
      *
-     * Title generation inspired by WebClients helper.ts:596 and client.ts:110
+     * Titles use a separate `lumo.target:'title'` completion (Lumo 2.0 no longer
+     * co-streams title with the message); it runs concurrently and is non-fatal.
      */
     async chatWithHistory(
         turns: Turn[],
@@ -226,10 +284,13 @@ export class LumoClient {
     ): Promise<ChatResult> {
         const {
             enableEncryption = this.defaultOptions?.enableEncryption ?? true,
-            endpoint = DEFAULT_ENDPOINT,
+            endpoint = LUMO_CHAT_ENDPOINT,
             requestTitle = false,
             instructions,
             injectInstructionsInto = 'first',
+            modelTier = this.defaultOptions?.modelTier ?? 'auto',
+            enableReasoning = this.defaultOptions?.enableReasoning ?? false,
+            onReasoning = this.defaultOptions?.onReasoning,
         } = options;
 
         const turn = turns[turns.length - 1];
@@ -247,87 +308,82 @@ export class LumoClient {
             ? [...DEFAULT_INTERNAL_TOOLS, ...DEFAULT_EXTERNAL_TOOLS]
             : DEFAULT_INTERNAL_TOOLS;
 
-        // Inject instructions into turns at the last moment (before encryption/API call)
-        // This keeps stored conversations clean - instructions are transient, not persisted
+        // Inject instructions at the last moment (kept out of persisted turns).
         const turnsWithInstructions = instructions
             ? injectInstructionsIntoTurns(turns, instructions, injectInstructionsInto)
             : turns;
 
-        let encryptionParams: RequestEncryptionParams | undefined;
-        let processedTurns: Turn[] = turnsWithInstructions;
-        let requestKeyEncB64: string | undefined;
+        // Title generation is a separate, concurrent, non-fatal completion.
+        const titlePromise = requestTitle
+            ? this.runCompletion(turns, {
+                endpoint,
+                tier: modelTier,
+                enableReasoning: false,
+                tools: [],
+                enableEncryption,
+                target: 'title',
+                isBounce: true, // no bounce handling for the title request
+            }).catch((error) => {
+                logger.warn({ error }, 'Title generation failed');
+                return null;
+            })
+            : null;
 
-        if (enableEncryption) {
-            const requestKey = await generateRequestKey();
-            const requestId = generateRequestId();
-            encryptionParams = new RequestEncryptionParams(requestKey, requestId);
-            requestKeyEncB64 = await encryptionParams.encryptRequestKey(DEFAULT_LUMO_PUB_KEY);
-            processedTurns = await encryptTurns(turnsWithInstructions, encryptionParams);
-        }
-
-        // Request title alongside message for new conversations
-        // See WebClients client.ts:110: targets = requestTitle ? ['title', 'message'] : ['message']
-        const targets: Array<'title' | 'message'> = requestTitle ? ['title', 'message'] : ['message'];
-
-        const request: LumoApiGenerationRequest = {
-            type: 'generation_request',
-            turns: processedTurns,
-            options: { tools },
-            targets,
-            ...(enableEncryption && requestKeyEncB64 && encryptionParams
-                ? {
-                    request_key: requestKeyEncB64,
-                    request_id: encryptionParams.requestId,
-                }
-                : {}),
-        };
-
-        const payload = { Prompt: request };
-
-        const stream = (await this.protonApi({
-            url: endpoint,
-            method: 'post',
-            data: payload,
-            output: 'stream',
-        })) as ReadableStream<Uint8Array>;
-
-        const result = await this.processStream(stream, onChunk, {
+        const main = await this.runCompletion(turnsWithInstructions, {
+            endpoint,
+            tier: modelTier,
+            enableReasoning,
+            tools,
             enableEncryption,
-            requestKey: encryptionParams?.requestKey,
-            requestId: encryptionParams?.requestId,
-        }, isBounce);
+            target: 'message',
+            onChunk,
+            onReasoning,
+            isBounce,
+        });
 
-        // Log response
         if (logConfig.messageContent) {
-            const responsePreview = result.message.content.length > 200
-                ? result.message.content.substring(0, 200) + '...'
-                : result.message.content;
+            const responsePreview = main.content.length > 200
+                ? main.content.substring(0, 200) + '...'
+                : main.content;
             logger.info(`[Lumo] ${responsePreview}`);
-            if (result.title) {
-                logger.debug({ title: result.title }, 'Generated title');
-            }
         }
 
-        // Bounce misrouted tool calls: ask Lumo to re-output as JSON text
-        if (!isBounce && result.misrouted && result._nativeToolCallForBounce) {
-            const bounceInstruction = buildBounceInstruction(result._nativeToolCallForBounce);
-            logger.info({ tool: result._nativeToolCallForBounce.name }, 'Bouncing misrouted tool call');
+        // Bounce misrouted tool calls: ask Lumo to re-output as JSON text.
+        if (!isBounce && main.native.misrouted && main.native.toolCall) {
+            const bounceInstruction = buildBounceInstruction(main.native.toolCall);
+            logger.info({ tool: main.native.toolCall.name }, 'Bouncing misrouted tool call');
 
             const bounceTurns: Turn[] = [
                 ...turns,
-                { role: Role.Assistant, content: result.message.content },
+                { role: Role.Assistant, content: main.content },
                 { role: Role.User, content: bounceInstruction },
             ];
 
             return this.chatWithHistory(bounceTurns, onChunk, options, true);
         }
 
-        // Post-process title (remove quotes, trim, limit length)
+        // Build message data for persistence.
+        const message: AssistantMessageData = { content: main.content };
+        if (main.native.toolCall && !main.native.misrouted) {
+            message.toolCall = JSON.stringify({
+                name: main.native.toolCall.name,
+                arguments: main.native.toolCall.arguments,
+            });
+            if (main.native.toolResult) {
+                message.toolResult = main.native.toolResult;
+            }
+        }
+
+        const titleResult = titlePromise ? await titlePromise : null;
+        const title = titleResult?.content ? postProcessTitle(titleResult.content) : undefined;
+
         return {
-            ...result,
-            title: result.title ? postProcessTitle(result.title) : undefined,
-            // Clear internal field from final result
-            _nativeToolCallForBounce: undefined,
+            message,
+            reasoning: main.reasoning || undefined,
+            usage: main.usage,
+            title,
+            nativeToolCallFailed: main.native.toolCall ? main.native.failed : undefined,
+            misrouted: main.native.misrouted,
         };
     }
 }

--- a/src/lumo-client/model-tier.ts
+++ b/src/lumo-client/model-tier.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps the inbound OpenAI `model` field to a Lumo tier, and the inbound
+ * `reasoning_effort` to a thinking-mode boolean.
+ */
+
+import type { LumoModelTier } from './types.js';
+
+/**
+ * Normalize a client-supplied model id: lowercase, trimmed, and stripped of any
+ * provider prefix (e.g. "proton/lumo-max" -> "lumo-max").
+ */
+export function normalizeModelId(model?: string): string {
+    if (!model) {
+        return '';
+    }
+    const lower = model.trim().toLowerCase();
+    const slash = lower.lastIndexOf('/');
+    return slash >= 0 ? lower.slice(slash + 1) : lower;
+}
+
+/** Map a normalized model id to a tier. `lumo`/`auto`/unknown-ish -> 'auto'. */
+export function modelToTier(normalizedModel: string): LumoModelTier {
+    switch (normalizedModel) {
+        case 'lumo-lite':
+            return 'lumo-lite';
+        case 'lumo-max':
+            return 'lumo-max';
+        default:
+            return 'auto';
+    }
+}
+
+/** True if the normalized model is in the allowed list (also normalized). */
+export function isModelAllowed(normalizedModel: string, allowedModels: string[]): boolean {
+    return allowedModels.some((m) => normalizeModelId(m) === normalizedModel);
+}
+
+/**
+ * Resolve the inbound reasoning_effort to a thinking-mode boolean.
+ * `none` -> false; `low`/`medium`/`high` -> true; absent -> config default.
+ */
+export function resolveReasoning(
+    effort: string | null | undefined,
+    defaultHigh: boolean,
+): boolean {
+    if (effort === undefined || effort === null) {
+        return defaultHigh;
+    }
+    return effort !== 'none';
+}

--- a/src/lumo-client/model-tier.ts
+++ b/src/lumo-client/model-tier.ts
@@ -9,13 +9,22 @@ import type { LumoModelTier } from './types.js';
  * Normalize a client-supplied model id: lowercase, trimmed, and stripped of any
  * provider prefix (e.g. "proton/lumo-max" -> "lumo-max").
  */
-export function normalizeModelId(model?: string): string {
-    if (!model) {
+export function normalizeModelId(model?: unknown): string {
+    if (typeof model !== 'string') {
         return '';
     }
     const lower = model.trim().toLowerCase();
     const slash = lower.lastIndexOf('/');
     return slash >= 0 ? lower.slice(slash + 1) : lower;
+}
+
+/** Valid inbound reasoning_effort values (plus absent/null meaning "use default"). */
+export const VALID_REASONING_EFFORTS = ['none', 'low', 'medium', 'high'] as const;
+
+/** True if the effort is absent/null or one of the valid string values. */
+export function isValidReasoningEffort(effort: unknown): boolean {
+    return effort === undefined || effort === null
+        || (typeof effort === 'string' && (VALID_REASONING_EFFORTS as readonly string[]).includes(effort));
 }
 
 /** Map a normalized model id to a tier. `lumo`/`auto`/unknown-ish -> 'auto'. */

--- a/src/lumo-client/types.ts
+++ b/src/lumo-client/types.ts
@@ -29,6 +29,22 @@ export interface ProtonApiOptions {
 
 export type ProtonApi = (options: ProtonApiOptions) => Promise<ReadableStream<Uint8Array> | unknown>;
 
+/**
+ * Error thrown by the ProtonApi transport for non-2xx responses.
+ * Carries the full Proton error context so callers can decode terminal errors
+ * (e.g. app-version rejection, tier/quota limits) from the response body.
+ */
+export interface ProtonApiError extends Error {
+    /** HTTP status code */
+    status?: number;
+    /** Proton API error code (from the response body's `Code` field) */
+    Code?: number;
+    /** Parsed JSON error body, if the response was JSON */
+    data?: unknown;
+    /** Raw response body text */
+    body?: string;
+}
+
 // Cached user keys structure (for persistence without core/v4/users scope)
 export interface CachedUserKey {
     ID: string;

--- a/src/lumo-client/types.ts
+++ b/src/lumo-client/types.ts
@@ -112,6 +112,24 @@ export interface AssistantMessageData {
 
 // LumoClient types
 
+/** OpenAI-style model id selecting the Lumo tier. */
+export type LumoModelTier = 'auto' | 'lumo-lite' | 'lumo-max';
+
+/**
+ * Usage/limit info from the chat/completions `usage` SSE chunk.
+ * Proton reports completion tokens + limit metadata, but NOT prompt or
+ * reasoning token counts, so those are intentionally absent.
+ */
+export interface LumoUsage {
+    completion_tokens?: number;
+    /** Which tier bucket the request was billed against ('lite' | 'max'). */
+    applied_limit_category?: string;
+    /** Remaining per-bucket limits, or null on unlimited plans. */
+    remaining_limits?: Record<string, number | null> | null;
+    /** Serving model id (hashed for encrypted requests). */
+    model?: string;
+}
+
 export interface LumoClientOptions {
     enableEncryption?: boolean;
     endpoint?: string;
@@ -120,12 +138,22 @@ export interface LumoClientOptions {
     instructions?: string;
     /** Where to inject instructions: 'first' or 'last' user turn. Default: 'first'. */
     injectInstructionsInto?: 'first' | 'last';
+    /** Model tier (Lite/Max). Defaults to 'auto'. */
+    modelTier?: LumoModelTier;
+    /** Thinking mode: request reasoning (reasoning_effort:'high'). */
+    enableReasoning?: boolean;
+    /** Sink for reasoning/thinking chunks (always drained, even if unused). */
+    onReasoning?: (content: string) => void;
 }
 
 /** Result from a chat request. */
 export interface ChatResult {
     /** Assistant message data ready for persistence */
     message: AssistantMessageData;
+    /** Accumulated reasoning/thinking text (when reasoning_effort was high) */
+    reasoning?: string;
+    /** Usage/limit metadata from the final `usage` chunk */
+    usage?: LumoUsage;
     /** Generated conversation title (for new conversations) */
     title?: string;
     /** Whether the native tool call failed server-side (tool_result contained error) */

--- a/src/lumo-client/types.ts
+++ b/src/lumo-client/types.ts
@@ -124,8 +124,10 @@ export interface LumoUsage {
     completion_tokens?: number;
     /** Which tier bucket the request was billed against ('lite' | 'max'). */
     applied_limit_category?: string;
-    /** Remaining per-bucket limits, or null on unlimited plans. */
+    /** Remaining per-bucket limits (lite/max/images), or null on unlimited plans. */
     remaining_limits?: Record<string, number | null> | null;
+    /** Whether an image-generation limit was applied. */
+    image_limit_applied?: boolean;
     /** Serving model id (hashed for encrypted requests). */
     model?: string;
 }

--- a/src/lumo-client/v2-body.ts
+++ b/src/lumo-client/v2-body.ts
@@ -11,10 +11,9 @@
  * from the legacy generation_request path.
  */
 
-import { Role, type Turn, type ToolName } from './types.js';
+import { Role, type Turn, type ToolName, type LumoModelTier } from './types.js';
 
-/** OpenAI-style model id that selects the Lumo tier. */
-export type LumoModelTier = 'auto' | 'lumo-lite' | 'lumo-max';
+export type { LumoModelTier };
 
 /** Lumo 2.0 unified endpoint (replaces the legacy `ai/v1/chat`). */
 export const LUMO_CHAT_ENDPOINT = 'ai/v1/chat/completions';

--- a/src/lumo-client/v2-body.ts
+++ b/src/lumo-client/v2-body.ts
@@ -1,0 +1,116 @@
+/**
+ * Lumo 2.0 chat/completions request body builder.
+ *
+ * Mirrors the wire format produced by Proton's web client:
+ * ProtonMail/WebClients applications/lumo/src/app/lib/lumo-api-client/core/chat-completions.ts
+ * (toChatCompletionsBody / resolveChatModel / buildLumoExtension / serializeMessages).
+ *
+ * Kept as a small local adapter (rather than syncing the upstream parser, which
+ * also carries image/legacy/tool-delta handling outside this project's scope).
+ * Reuses the vendored encryption primitives unchanged; only the packaging differs
+ * from the legacy generation_request path.
+ */
+
+import { Role, type Turn, type ToolName } from './types.js';
+
+/** OpenAI-style model id that selects the Lumo tier. */
+export type LumoModelTier = 'auto' | 'lumo-lite' | 'lumo-max';
+
+/** Lumo 2.0 unified endpoint (replaces the legacy `ai/v1/chat`). */
+export const LUMO_CHAT_ENDPOINT = 'ai/v1/chat/completions';
+
+/** Which completion is requested; a title is a separate targeted completion. */
+export type LumoCompletionTarget = 'message' | 'title';
+
+/** Map a tier to the wire `model` value. `auto` -> `lumo` (Proton routes). */
+export function resolveChatModel(tier: LumoModelTier): string {
+    switch (tier) {
+        case 'lumo-lite':
+            return 'lumo-lite';
+        case 'lumo-max':
+            return 'lumo-max';
+        default:
+            return 'lumo';
+    }
+}
+
+/** Map a Turn role to the chat/completions message role (see serializeMessages). */
+function messageRole(role: Role): string {
+    switch (role) {
+        case Role.ToolResult:
+            return 'tool';
+        case Role.ToolCall:
+            return 'lumo_tool_call';
+        default:
+            return role; // 'user' | 'assistant' | 'system' are already wire values
+    }
+}
+
+export interface BuildChatBodyParams {
+    /** Turns to send. Already encrypted when `encrypted` is true. */
+    turns: Turn[];
+    tier: LumoModelTier;
+    /** Thinking mode: true -> reasoning_effort:'high', false -> 'none'. */
+    enableReasoning: boolean;
+    /** Native tool names to enable (e.g. proton_info, web_search). */
+    tools?: ToolName[];
+    /** Present when U2L encryption is on; folded into the `lumo` extension. */
+    encryption?: { requestKeyEncB64: string; requestId: string };
+    /** Whether `turns` carry encrypted content (sets message-level `encrypted`). */
+    encrypted: boolean;
+    /** Completion target; defaults to 'message'. 'title' requests a title. */
+    target?: LumoCompletionTarget;
+}
+
+/** The `lumo` request extension (auth-independent metadata + encryption keys). */
+export interface LumoExtension {
+    client_type: 'frontend';
+    target?: LumoCompletionTarget;
+    request_key?: string;
+    request_id?: string;
+}
+
+export interface ChatCompletionsBody {
+    model: string;
+    messages: Array<{ role: string; content: string; encrypted?: true }>;
+    stream: true;
+    stream_options: { include_usage: true };
+    reasoning_effort: 'high' | 'none';
+    tools?: Array<{ name: string }>;
+    tool_choice?: 'auto';
+    lumo: LumoExtension;
+}
+
+/** Build the POST body for `ai/v1/chat/completions`. */
+export function buildChatCompletionsBody(params: BuildChatBodyParams): ChatCompletionsBody {
+    const messages = params.turns.map((turn) => ({
+        role: messageRole(turn.role),
+        content: turn.content ?? '',
+        ...(params.encrypted ? { encrypted: true as const } : {}),
+    }));
+
+    const lumo: LumoExtension = { client_type: 'frontend' };
+    if (params.target) {
+        lumo.target = params.target;
+    }
+    if (params.encryption) {
+        lumo.request_key = params.encryption.requestKeyEncB64;
+        lumo.request_id = params.encryption.requestId;
+    }
+
+    const body: ChatCompletionsBody = {
+        model: resolveChatModel(params.tier),
+        messages,
+        stream: true,
+        stream_options: { include_usage: true },
+        reasoning_effort: params.enableReasoning ? 'high' : 'none',
+        lumo,
+    };
+
+    if (params.tools && params.tools.length > 0) {
+        body.tools = params.tools.map((name) => ({ name }));
+        body.tool_choice = 'auto';
+    }
+
+    return body;
+}

--- a/src/lumo-client/v2-stream.ts
+++ b/src/lumo-client/v2-stream.ts
@@ -27,7 +27,7 @@ interface OpenAiDelta {
     reasoning_content?: string;
     reasoning?: string;
     encrypted?: boolean;
-    target?: 'message' | 'reasoning' | 'tool_call';
+    target?: string;
     tool_calls?: Array<{
         index?: number;
         function?: { name?: string; arguments?: string };
@@ -61,6 +61,7 @@ export class V2StreamProcessor {
             this.handleLine(this.buffer, messages);
             this.buffer = '';
         }
+        this.flushToolCalls(messages);
         return messages;
     }
 
@@ -124,7 +125,12 @@ export class V2StreamProcessor {
         }
 
         if (obj.usage) {
-            out.push({ type: 'usage', usage: obj.usage as LumoUsage });
+            const usage = obj.usage as LumoUsage;
+            // The serving model id is a top-level field on the chunk.
+            if (usage.model === undefined && typeof obj.model === 'string') {
+                usage.model = obj.model;
+            }
+            out.push({ type: 'usage', usage });
         }
 
         const choices = obj.choices as Array<{ finish_reason?: string; delta?: OpenAiDelta }> | undefined;
@@ -138,32 +144,36 @@ export class V2StreamProcessor {
         if (!choice.delta) {
             return;
         }
-        this.processDelta(choice.delta, out);
+        const topTarget = typeof obj.target === 'string' ? obj.target : undefined;
+        this.processDelta(choice.delta, topTarget, out);
     }
 
-    private processDelta(delta: OpenAiDelta, out: V2StreamMessage[]): void {
-        const target = delta.target ?? 'message';
+    private processDelta(delta: OpenAiDelta, topTarget: string | undefined, out: V2StreamMessage[]): void {
+        // Honor an explicit reasoning target; otherwise content is message text.
+        const rawTarget = delta.target ?? topTarget ?? 'message';
+        const contentTarget: 'message' | 'reasoning' | 'tool_call' =
+            rawTarget === 'reasoning' || rawTarget === 'tool_call' ? rawTarget : 'message';
+
         if (typeof delta.content === 'string' && delta.content.length > 0) {
-            out.push({ type: 'token_data', target: target === 'reasoning' ? 'message' : target, content: delta.content, encrypted: delta.encrypted });
+            out.push({ type: 'token_data', target: contentTarget, content: delta.content, encrypted: delta.encrypted });
         }
         const reasoning = delta.reasoning_content ?? delta.reasoning;
         if (typeof reasoning === 'string' && reasoning.length > 0) {
             out.push({ type: 'token_data', target: 'reasoning', content: reasoning, encrypted: delta.encrypted });
         }
+        // Accumulate tool-call deltas; a single complete call is emitted in finalize()
+        // so the consumer sees full arguments (not an early empty-argument snapshot).
         if (Array.isArray(delta.tool_calls)) {
             for (const tc of delta.tool_calls) {
-                const emitted = this.accumulateToolCall(tc);
-                if (emitted) {
-                    out.push(emitted);
-                }
+                this.accumulateToolCall(tc);
             }
         }
     }
 
-    /** Accumulate a streamed tool-call delta; emit token_data once a name is known. */
+    /** Accumulate one streamed tool-call delta by index. */
     private accumulateToolCall(
         tc: { index?: number; function?: { name?: string; arguments?: string } },
-    ): V2StreamMessage | null {
+    ): void {
         const index = tc.index ?? 0;
         const existing = this.toolCalls.get(index) ?? { name: '', arguments: '' };
         if (tc.function?.name) {
@@ -173,18 +183,24 @@ export class V2StreamProcessor {
             existing.arguments += tc.function.arguments;
         }
         this.toolCalls.set(index, existing);
-        if (!existing.name) {
-            return null;
-        }
-        let args: Record<string, unknown> = {};
-        if (existing.arguments) {
-            try {
-                args = JSON.parse(existing.arguments);
-            } catch {
-                // arguments still streaming; emit best-effort with raw string
-                return { type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: existing.name, arguments: existing.arguments }) };
+    }
+
+    /** Emit one complete token_data tool_call per accumulated index. */
+    private flushToolCalls(out: V2StreamMessage[]): void {
+        for (const tc of this.toolCalls.values()) {
+            if (!tc.name) {
+                continue;
             }
+            let args: unknown = {};
+            if (tc.arguments) {
+                try {
+                    args = JSON.parse(tc.arguments);
+                } catch {
+                    args = tc.arguments; // incomplete/invalid JSON: pass through raw
+                }
+            }
+            out.push({ type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: tc.name, arguments: args }) });
         }
-        return { type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: existing.name, arguments: args }) };
+        this.toolCalls.clear();
     }
 }

--- a/src/lumo-client/v2-stream.ts
+++ b/src/lumo-client/v2-stream.ts
@@ -1,0 +1,190 @@
+/**
+ * Lumo 2.0 chat/completions SSE parser.
+ *
+ * Normalizes the OpenAI-style stream returned by `ai/v1/chat/completions` into
+ * a small message union the LumoClient consumes. Mirrors the dispatch logic of
+ * ProtonMail/WebClients applications/lumo/src/app/lib/lumo-api-client/core/streaming.ts
+ * (processOpenAiChunk / processDelta / processToolCallDelta / chat.tool_call|result),
+ * kept as a local adapter scoped to what this proxy needs (no image handling).
+ *
+ * Content and reasoning arrive encrypted (U2L) and are decrypted by the caller
+ * using the per-request AD; this parser only surfaces the `encrypted` flag.
+ */
+
+import type { LumoUsage } from './types.js';
+
+export type V2StreamMessage =
+    | { type: 'token_data'; target: 'message' | 'reasoning' | 'tool_call'; content: string; encrypted?: boolean }
+    | { type: 'server_tool_call'; call_id?: string; name: string; arguments?: string; encrypted?: boolean }
+    | { type: 'server_tool_result'; call_id?: string; content: string; encrypted?: boolean }
+    | { type: 'usage'; usage: LumoUsage }
+    | { type: 'harmful' }
+    | { type: 'error'; message?: string }
+    | { type: 'done' };
+
+interface OpenAiDelta {
+    content?: string;
+    reasoning_content?: string;
+    reasoning?: string;
+    encrypted?: boolean;
+    target?: 'message' | 'reasoning' | 'tool_call';
+    tool_calls?: Array<{
+        index?: number;
+        function?: { name?: string; arguments?: string };
+    }>;
+}
+
+/**
+ * Stateful line-buffered SSE parser. Feed raw decoded chunks to `processChunk`
+ * and flush any trailing buffered line with `finalize`.
+ */
+export class V2StreamProcessor {
+    private buffer = '';
+    /** Accumulates streamed tool-call name/arguments by index. */
+    private toolCalls = new Map<number, { name: string; arguments: string }>();
+
+    processChunk(chunk: string): V2StreamMessage[] {
+        this.buffer += chunk;
+        const messages: V2StreamMessage[] = [];
+        let nl: number;
+        while ((nl = this.buffer.indexOf('\n')) >= 0) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            this.handleLine(line, messages);
+        }
+        return messages;
+    }
+
+    finalize(): V2StreamMessage[] {
+        const messages: V2StreamMessage[] = [];
+        if (this.buffer.length > 0) {
+            this.handleLine(this.buffer, messages);
+            this.buffer = '';
+        }
+        return messages;
+    }
+
+    private handleLine(rawLine: string, out: V2StreamMessage[]): void {
+        // Tolerate CRLF and the optional "data:" SSE prefix.
+        let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+        line = line.replace(/^data:\s*/, '').trim();
+        if (!line || line.startsWith(':')) {
+            return; // blank line or SSE comment
+        }
+        if (line === '[DONE]') {
+            out.push({ type: 'done' });
+            return;
+        }
+        let obj: Record<string, unknown>;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            return; // ignore malformed/partial JSON lines
+        }
+        this.dispatch(obj, out);
+    }
+
+    private dispatch(obj: Record<string, unknown>, out: V2StreamMessage[]): void {
+        const objectType = obj.object;
+
+        if (objectType === 'chat.tool_call') {
+            const tc = (obj.tool_call ?? {}) as { id?: string; name?: string; arguments?: string; encrypted?: boolean };
+            if (tc.name) {
+                out.push({
+                    type: 'server_tool_call',
+                    call_id: tc.id,
+                    name: tc.name,
+                    ...(tc.arguments !== undefined ? { arguments: tc.arguments } : {}),
+                    ...(tc.encrypted ? { encrypted: true } : {}),
+                });
+            }
+            return;
+        }
+
+        if (objectType === 'chat.tool_result') {
+            const tr = (obj.tool_result ?? {}) as { call_id?: string; content?: string; encrypted?: boolean };
+            out.push({
+                type: 'server_tool_result',
+                call_id: tr.call_id,
+                content: tr.content ?? '',
+                ...(tr.encrypted ? { encrypted: true } : {}),
+            });
+            return;
+        }
+
+        if (objectType === 'lumo.image_data') {
+            return; // image generation not surfaced by this proxy
+        }
+
+        // OpenAI-style completion chunk.
+        if (obj.error) {
+            const err = obj.error as { message?: string; code?: string };
+            out.push({ type: 'error', message: err.message ?? err.code });
+            return;
+        }
+
+        if (obj.usage) {
+            out.push({ type: 'usage', usage: obj.usage as LumoUsage });
+        }
+
+        const choices = obj.choices as Array<{ finish_reason?: string; delta?: OpenAiDelta }> | undefined;
+        if (!choices || choices.length === 0) {
+            return;
+        }
+        const choice = choices[0];
+        if (choice.finish_reason === 'content_filter') {
+            out.push({ type: 'harmful' });
+        }
+        if (!choice.delta) {
+            return;
+        }
+        this.processDelta(choice.delta, out);
+    }
+
+    private processDelta(delta: OpenAiDelta, out: V2StreamMessage[]): void {
+        const target = delta.target ?? 'message';
+        if (typeof delta.content === 'string' && delta.content.length > 0) {
+            out.push({ type: 'token_data', target: target === 'reasoning' ? 'message' : target, content: delta.content, encrypted: delta.encrypted });
+        }
+        const reasoning = delta.reasoning_content ?? delta.reasoning;
+        if (typeof reasoning === 'string' && reasoning.length > 0) {
+            out.push({ type: 'token_data', target: 'reasoning', content: reasoning, encrypted: delta.encrypted });
+        }
+        if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+                const emitted = this.accumulateToolCall(tc);
+                if (emitted) {
+                    out.push(emitted);
+                }
+            }
+        }
+    }
+
+    /** Accumulate a streamed tool-call delta; emit token_data once a name is known. */
+    private accumulateToolCall(
+        tc: { index?: number; function?: { name?: string; arguments?: string } },
+    ): V2StreamMessage | null {
+        const index = tc.index ?? 0;
+        const existing = this.toolCalls.get(index) ?? { name: '', arguments: '' };
+        if (tc.function?.name) {
+            existing.name = tc.function.name;
+        }
+        if (tc.function?.arguments) {
+            existing.arguments += tc.function.arguments;
+        }
+        this.toolCalls.set(index, existing);
+        if (!existing.name) {
+            return null;
+        }
+        let args: Record<string, unknown> = {};
+        if (existing.arguments) {
+            try {
+                args = JSON.parse(existing.arguments);
+            } catch {
+                // arguments still streaming; emit best-effort with raw string
+                return { type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: existing.name, arguments: existing.arguments }) };
+            }
+        }
+        return { type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: existing.name, arguments: args }) };
+    }
+}

--- a/src/mock/custom-scenarios.ts
+++ b/src/mock/custom-scenarios.ts
@@ -9,9 +9,18 @@ import { Role, type Turn, type ProtonApiOptions } from '../lumo-client/types.js'
 import { formatSSEMessage, delay, type ScenarioGenerator } from './mock-api.js';
 import { getServerInstructionsConfig, getCustomToolsConfig } from '../app/config.js';
 
-/** Extract turns from the mock request payload (unencrypted only). */
+/** Extract turns from the mock request payload (unencrypted only).
+ *  Supports the Lumo 2.0 chat/completions body (`messages`) and the legacy
+ *  generation_request body (`Prompt.turns`). */
 function getTurns(options: ProtonApiOptions): Turn[] {
-    return (options.data as any)?.Prompt?.turns ?? [];
+    const body = options.data as {
+        messages?: Array<{ role: Turn['role']; content?: string }>;
+        Prompt?: { turns?: Turn[] };
+    };
+    if (Array.isArray(body?.messages)) {
+        return body.messages.map((m) => ({ role: m.role, content: m.content })) as Turn[];
+    }
+    return body?.Prompt?.turns ?? [];
 }
 
 /** Find the last turn with a given role. */

--- a/src/mock/mock-api.ts
+++ b/src/mock/mock-api.ts
@@ -35,6 +35,56 @@ type Scenario = MockConfig['scenario'];
 const callCounts = new Map<string, number>();
 const MAX_CALLS = 10;
 
+const v2chunk = (fields: Record<string, unknown>) =>
+    `data: ${JSON.stringify({ object: 'CompletionChunk', model: 'lumo-mock', ...fields })}\n\n`;
+const v2object = (obj: Record<string, unknown>) => `data: ${JSON.stringify(obj)}\n\n`;
+
+/**
+ * Translate a legacy generation_request SSE line (the format the vendored/custom
+ * scenarios still emit) into the Lumo 2.0 chat/completions OpenAI-style SSE the
+ * client now parses. Keeps scenarios untouched while the mock speaks v2.
+ */
+function translateToV2(legacyChunk: string): string {
+    const trimmed = legacyChunk.replace(/^data:\s*/, '').trim();
+    if (!trimmed) return '';
+    let msg: Record<string, unknown>;
+    try {
+        msg = JSON.parse(trimmed);
+    } catch {
+        return '';
+    }
+    switch (msg.type) {
+        case 'token_data': {
+            const content = typeof msg.content === 'string' ? msg.content : '';
+            if (msg.target === 'message') return v2chunk({ choices: [{ index: 0, delta: { content } }] });
+            if (msg.target === 'reasoning') return v2chunk({ choices: [{ index: 0, delta: { reasoning: content } }] });
+            if (msg.target === 'title') return ''; // v2 titles are a separate completion
+            if (msg.target === 'tool_call') {
+                try {
+                    const parsed = JSON.parse(content);
+                    const args = JSON.stringify(parsed.parameters ?? parsed.arguments ?? {});
+                    return v2object({ object: 'chat.tool_call', tool_call: { name: parsed.name, arguments: args } });
+                } catch {
+                    return '';
+                }
+            }
+            if (msg.target === 'tool_result') {
+                return v2object({ object: 'chat.tool_result', tool_result: { content } });
+            }
+            return '';
+        }
+        case 'done':
+            return 'data: [DONE]\n\n';
+        case 'error':
+        case 'timeout':
+        case 'rejected':
+        case 'harmful':
+            return v2chunk({ error: { code: msg.type, message: (msg.message as string) ?? String(msg.type) } });
+        default:
+            return ''; // ingesting/queued and other no-ops
+    }
+}
+
 function createStream(scenario: string, generator: ScenarioGenerator, options: ProtonApiOptions): ReadableStream<Uint8Array> {
     const encoder = new TextEncoder();
     return new ReadableStream({
@@ -45,7 +95,7 @@ function createStream(scenario: string, generator: ScenarioGenerator, options: P
             if (callNum > MAX_CALLS) {
                 logger.warn({ scenario, callNum }, `Mock safety limit: ${MAX_CALLS} calls exceeded`);
                 controller.enqueue(encoder.encode(
-                    formatSSEMessage({ type: 'error', message: `Mock safety limit: ${MAX_CALLS} calls exceeded` })
+                    v2chunk({ error: { code: 'error', message: `Mock safety limit: ${MAX_CALLS} calls exceeded` } })
                 ));
                 controller.close();
                 return;
@@ -53,7 +103,8 @@ function createStream(scenario: string, generator: ScenarioGenerator, options: P
 
             try {
                 for await (const chunk of generator(options)) {
-                    controller.enqueue(encoder.encode(chunk));
+                    const v2 = translateToV2(chunk);
+                    if (v2) controller.enqueue(encoder.encode(v2));
                 }
                 controller.close();
             } catch (error) {

--- a/tests/integration/health-models.test.ts
+++ b/tests/integration/health-models.test.ts
@@ -27,21 +27,22 @@ describe('GET /health', () => {
 });
 
 describe('GET /v1/models', () => {
-  it('returns list with single model', async () => {
+  it('returns the list of allowed model tiers', async () => {
     const res = await fetch(`${ts.baseUrl}/v1/models`);
     expect(res.status).toBe(200);
 
     const body = await res.json();
     expect(body.object).toBe('list');
-    expect(body.data).toHaveLength(1);
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
     expect(body.data[0].object).toBe('model');
     expect(body.data[0].owned_by).toBe('proton');
   });
 
-  it('model id matches config apiModelName', async () => {
+  it('advertises the tier models from config.allowedModels', async () => {
     const res = await fetch(`${ts.baseUrl}/v1/models`);
     const body = await res.json();
-    // Default from config.defaults.yaml
-    expect(body.data[0].id).toBe('lumo');
+    const ids = body.data.map((m: { id: string }) => m.id);
+    // Defaults from config.defaults.yaml
+    expect(ids).toEqual(['lumo', 'lumo-lite', 'lumo-max']);
   });
 });

--- a/tests/integration/model-tier-api.test.ts
+++ b/tests/integration/model-tier-api.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestServer, type TestServer } from '../helpers/test-server.js';
+
+describe('model tier + reasoning (chat/completions)', () => {
+    let ts: TestServer;
+    beforeAll(async () => { ts = await createTestServer('success'); });
+    afterAll(async () => { await ts.close(); });
+
+    async function chat(body: object) {
+        return fetch(`${ts.baseUrl}/v1/chat/completions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+
+    it('accepts a valid tier model', async () => {
+        const res = await chat({ model: 'lumo-max', messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.choices[0].message.content).toContain('Mocked');
+    });
+
+    it('accepts a provider-prefixed tier model', async () => {
+        const res = await chat({ model: 'proton/lumo-lite', messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(200);
+    });
+
+    it('rejects an unknown model with a 400', async () => {
+        const res = await chat({ model: 'gpt-4', messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error.type).toBe('invalid_request_error');
+        expect(body.error.code).toBe('model_not_found');
+        expect(body.error.param).toBe('model');
+    });
+
+    it('accepts reasoning_effort', async () => {
+        const res = await chat({ model: 'lumo-max', reasoning_effort: 'high', messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(200);
+    });
+});

--- a/tests/integration/model-tier-api.test.ts
+++ b/tests/integration/model-tier-api.test.ts
@@ -39,4 +39,19 @@ describe('model tier + reasoning (chat/completions)', () => {
         const res = await chat({ model: 'lumo-max', reasoning_effort: 'high', messages: [{ role: 'user', content: 'hi' }] });
         expect(res.status).toBe(200);
     });
+
+    it('rejects an invalid reasoning_effort with a 400', async () => {
+        const res = await chat({ reasoning_effort: 'ludicrous', messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error.code).toBe('invalid_reasoning_effort');
+        expect(body.error.param).toBe('reasoning_effort');
+    });
+
+    it('rejects a non-string model with a 400 (not a 500)', async () => {
+        const res = await chat({ model: 123, messages: [{ role: 'user', content: 'hi' }] });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error.code).toBe('model_not_found');
+    });
 });

--- a/tests/unit/api-factory.test.ts
+++ b/tests/unit/api-factory.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createProtonApi } from '../../src/auth/api-factory.js';
+import type { ProtonApiError } from '../../src/lumo-client/types.js';
+
+describe('createProtonApi error handling', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('preserves parsed and raw Proton error body on non-2xx JSON responses', async () => {
+        const bodyText = JSON.stringify({ Code: 5003, Error: 'App version outdated' });
+        vi.stubGlobal('fetch', vi.fn(async () =>
+            new Response(bodyText, { status: 400, statusText: 'Bad Request' })));
+
+        const api = createProtonApi({ uid: 'u', accessToken: 't' });
+
+        await expect(
+            api({ url: 'ai/v1/chat/completions', method: 'post', data: {} })
+        ).rejects.toMatchObject({
+            message: 'App version outdated',
+            status: 400,
+            Code: 5003,
+            data: { Code: 5003, Error: 'App version outdated' },
+            body: bodyText,
+        });
+    });
+
+    it('falls back to status text and keeps the raw body when not JSON', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () =>
+            new Response('gateway boom', { status: 502, statusText: 'Bad Gateway' })));
+
+        const api = createProtonApi({ uid: 'u', accessToken: 't' });
+
+        let err: ProtonApiError | undefined;
+        try {
+            await api({ url: 'ai/v1/limits', method: 'get' });
+        } catch (e) {
+            err = e as ProtonApiError;
+        }
+
+        expect(err?.status).toBe(502);
+        expect(err?.body).toBe('gateway boom');
+        expect(err?.data).toBeUndefined();
+        expect(err?.message).toContain('502');
+    });
+});

--- a/tests/unit/lumo-client.test.ts
+++ b/tests/unit/lumo-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LumoClient } from '../../src/lumo-client/client.js';
+import { Role } from '../../src/lumo-client/types.js';
+import type { ProtonApiOptions } from '../../src/lumo-client/types.js';
+
+/** Build a fake SSE ReadableStream from CompletionChunk objects, ending with [DONE]. */
+function sseStream(chunks: object[]): ReadableStream<Uint8Array> {
+    const enc = new TextEncoder();
+    const lines = [...chunks.map((c) => `data:${JSON.stringify(c)}\n`), 'data:[DONE]\n'];
+    return new ReadableStream({
+        start(controller) {
+            for (const l of lines) controller.enqueue(enc.encode(l));
+            controller.close();
+        },
+    });
+}
+
+const cc = (delta: object, extra: object = {}) => ({
+    object: 'CompletionChunk', model: 'lumo-max', choices: [{ index: 0, delta }], ...extra,
+});
+
+/** LumoClient wired to a plaintext fake transport (no encryption). */
+function makeClient(handler: (opts: ProtonApiOptions) => object[]) {
+    const api = vi.fn(async (opts: ProtonApiOptions) => sseStream(handler(opts)));
+    const client = new LumoClient(api as never, { enableEncryption: false });
+    return { client, api };
+}
+
+describe('LumoClient (Lumo 2.0 chat/completions)', () => {
+    it('accumulates reasoning separately from content, even without an onReasoning sink', async () => {
+        const { client } = makeClient(() => [cc({ content: 'Answer' }), cc({ reasoning: 'thinking' })]);
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'hi' }]);
+        expect(res.message.content).toBe('Answer');
+        expect(res.reasoning).toBe('thinking');
+    });
+
+    it('does not leak reasoning-targeted content into the answer', async () => {
+        const { client } = makeClient(() => [
+            cc({ content: 'visible' }),
+            { object: 'CompletionChunk', choices: [{ delta: { target: 'reasoning', content: 'hidden' } }] },
+        ]);
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'hi' }]);
+        expect(res.message.content).toBe('visible');
+        expect(res.reasoning).toBe('hidden');
+    });
+
+    it('captures the full tool-call arguments from streamed deltas', async () => {
+        const { client } = makeClient(() => [
+            cc({ tool_calls: [{ index: 0, function: { name: 'web_search' } }] }),
+            cc({ tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] }),
+            cc({ tool_calls: [{ index: 0, function: { arguments: '"cats"}' } }] }),
+        ]);
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'find cats' }]);
+        expect(res.message.toolCall).toBeDefined();
+        expect(JSON.parse(res.message.toolCall!)).toEqual({ name: 'web_search', arguments: { q: 'cats' } });
+    });
+
+    it('captures usage (tier category + serving model)', async () => {
+        const { client } = makeClient(() => [
+            cc({ content: 'x' }),
+            { object: 'CompletionChunk', model: 'lumo-max', choices: [], usage: { completion_tokens: 2, applied_limit_category: 'max' } },
+        ]);
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'hi' }]);
+        expect(res.usage).toEqual({ completion_tokens: 2, applied_limit_category: 'max', model: 'lumo-max' });
+    });
+
+    it('issues a separate title completion and uses its content', async () => {
+        const { client, api } = makeClient((opts) => {
+            const target = (opts.data as { lumo?: { target?: string } }).lumo?.target;
+            return target === 'title' ? [cc({ content: 'A Good Title' })] : [cc({ content: 'body' })];
+        });
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'hi' }], undefined, { requestTitle: true });
+        expect(api).toHaveBeenCalledTimes(2);
+        expect(res.message.content).toBe('body');
+        expect(res.title).toBe('A Good Title');
+    });
+
+    it('bounces a misrouted custom tool and requests the title only once', async () => {
+        let messageCalls = 0;
+        let titleCalls = 0;
+        const { client } = makeClient((opts) => {
+            const target = (opts.data as { lumo?: { target?: string } }).lumo?.target;
+            if (target === 'title') {
+                titleCalls++;
+                return [cc({ content: 'Title' })];
+            }
+            messageCalls++;
+            return messageCalls === 1
+                ? [cc({ tool_calls: [{ index: 0, function: { name: 'my_custom_tool', arguments: '{"a":1}' } }] })]
+                : [cc({ content: 'final answer' })];
+        });
+        const res = await client.chatWithHistory([{ role: Role.User, content: 'hi' }], undefined, { requestTitle: true });
+        expect(res.message.content).toBe('final answer');
+        expect(res.title).toBe('Title');
+        expect(titleCalls).toBe(1);
+        expect(messageCalls).toBe(2);
+    });
+
+    it('sends tier and reasoning_effort in the request body', async () => {
+        const { client, api } = makeClient(() => [cc({ content: 'ok' })]);
+        await client.chatWithHistory([{ role: Role.User, content: 'hi' }], undefined, {
+            modelTier: 'lumo-max', enableReasoning: true,
+        });
+        const body = api.mock.calls[0][0].data as { model: string; reasoning_effort: string };
+        expect(body.model).toBe('lumo-max');
+        expect(body.reasoning_effort).toBe('high');
+    });
+});

--- a/tests/unit/model-tier.test.ts
+++ b/tests/unit/model-tier.test.ts
@@ -1,11 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeModelId, modelToTier, isModelAllowed, resolveReasoning } from '../../src/lumo-client/model-tier.js';
+import { normalizeModelId, modelToTier, isModelAllowed, resolveReasoning, isValidReasoningEffort } from '../../src/lumo-client/model-tier.js';
 
 describe('normalizeModelId', () => {
     it('lowercases, trims, and strips a provider prefix', () => {
         expect(normalizeModelId('  Lumo-Max ')).toBe('lumo-max');
         expect(normalizeModelId('proton/lumo-max')).toBe('lumo-max');
         expect(normalizeModelId(undefined)).toBe('');
+    });
+    it('returns empty string for non-string input (no throw)', () => {
+        expect(normalizeModelId(42 as unknown)).toBe('');
+        expect(normalizeModelId({} as unknown)).toBe('');
+        expect(normalizeModelId(null)).toBe('');
+    });
+});
+
+describe('isValidReasoningEffort', () => {
+    it('accepts valid values and absent/null', () => {
+        for (const e of ['none', 'low', 'medium', 'high', undefined, null]) {
+            expect(isValidReasoningEffort(e)).toBe(true);
+        }
+    });
+    it('rejects invalid values (including wrong case and non-strings)', () => {
+        for (const e of ['NONE', 'HIGH', 'typo', '', 5, {}]) {
+            expect(isValidReasoningEffort(e)).toBe(false);
+        }
     });
 });
 

--- a/tests/unit/model-tier.test.ts
+++ b/tests/unit/model-tier.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeModelId, modelToTier, isModelAllowed, resolveReasoning } from '../../src/lumo-client/model-tier.js';
+
+describe('normalizeModelId', () => {
+    it('lowercases, trims, and strips a provider prefix', () => {
+        expect(normalizeModelId('  Lumo-Max ')).toBe('lumo-max');
+        expect(normalizeModelId('proton/lumo-max')).toBe('lumo-max');
+        expect(normalizeModelId(undefined)).toBe('');
+    });
+});
+
+describe('modelToTier', () => {
+    it('maps model ids to tiers', () => {
+        expect(modelToTier('lumo')).toBe('auto');
+        expect(modelToTier('lumo-lite')).toBe('lumo-lite');
+        expect(modelToTier('lumo-max')).toBe('lumo-max');
+        expect(modelToTier('something-else')).toBe('auto');
+    });
+});
+
+describe('isModelAllowed', () => {
+    const allowed = ['lumo', 'lumo-lite', 'lumo-max'];
+    it('accepts allowed models (normalized) and rejects others', () => {
+        expect(isModelAllowed('lumo-max', allowed)).toBe(true);
+        expect(isModelAllowed(normalizeModelId('proton/lumo'), allowed)).toBe(true);
+        expect(isModelAllowed('gpt-4', allowed)).toBe(false);
+    });
+});
+
+describe('resolveReasoning', () => {
+    it('maps reasoning_effort to a thinking-mode boolean', () => {
+        expect(resolveReasoning('none', false)).toBe(false);
+        expect(resolveReasoning('low', false)).toBe(true);
+        expect(resolveReasoning('medium', false)).toBe(true);
+        expect(resolveReasoning('high', false)).toBe(true);
+    });
+    it('falls back to the config default when absent', () => {
+        expect(resolveReasoning(undefined, false)).toBe(false);
+        expect(resolveReasoning(undefined, true)).toBe(true);
+        expect(resolveReasoning(null, true)).toBe(true);
+    });
+});

--- a/tests/unit/v2-body.test.ts
+++ b/tests/unit/v2-body.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { buildChatCompletionsBody, resolveChatModel } from '../../src/lumo-client/v2-body.js';
+import { Role } from '../../src/lumo-client/types.js';
+
+describe('resolveChatModel', () => {
+    it('maps tiers to wire model ids', () => {
+        expect(resolveChatModel('auto')).toBe('lumo');
+        expect(resolveChatModel('lumo-lite')).toBe('lumo-lite');
+        expect(resolveChatModel('lumo-max')).toBe('lumo-max');
+    });
+});
+
+describe('buildChatCompletionsBody', () => {
+    const baseTurns = [{ role: Role.User, content: 'hi' }];
+
+    it('builds a minimal plaintext body', () => {
+        const body = buildChatCompletionsBody({
+            turns: baseTurns,
+            tier: 'lumo-max',
+            enableReasoning: false,
+            encrypted: false,
+        });
+        expect(body.model).toBe('lumo-max');
+        expect(body.stream).toBe(true);
+        expect(body.stream_options).toEqual({ include_usage: true });
+        expect(body.reasoning_effort).toBe('none');
+        expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+        expect(body.lumo).toEqual({ client_type: 'frontend' });
+        expect(body.tools).toBeUndefined();
+        expect(body.tool_choice).toBeUndefined();
+    });
+
+    it('sets reasoning_effort high when reasoning enabled', () => {
+        const body = buildChatCompletionsBody({
+            turns: baseTurns, tier: 'auto', enableReasoning: true, encrypted: false,
+        });
+        expect(body.reasoning_effort).toBe('high');
+    });
+
+    it('folds encryption keys into the lumo extension and flags messages', () => {
+        const body = buildChatCompletionsBody({
+            turns: [{ role: Role.User, content: 'CIPHERTEXT' }],
+            tier: 'auto',
+            enableReasoning: false,
+            encrypted: true,
+            encryption: { requestKeyEncB64: 'KEY', requestId: 'RID' },
+        });
+        expect(body.messages[0]).toEqual({ role: 'user', content: 'CIPHERTEXT', encrypted: true });
+        expect(body.lumo).toEqual({ client_type: 'frontend', request_key: 'KEY', request_id: 'RID' });
+    });
+
+    it('normalizes tools and sets tool_choice', () => {
+        const body = buildChatCompletionsBody({
+            turns: baseTurns, tier: 'auto', enableReasoning: false, encrypted: false,
+            tools: ['proton_info', 'web_search'],
+        });
+        expect(body.tools).toEqual([{ name: 'proton_info' }, { name: 'web_search' }]);
+        expect(body.tool_choice).toBe('auto');
+    });
+
+    it('carries the title target in the lumo extension', () => {
+        const body = buildChatCompletionsBody({
+            turns: baseTurns, tier: 'auto', enableReasoning: false, encrypted: false, target: 'title',
+        });
+        expect(body.lumo.target).toBe('title');
+    });
+
+    it('maps tool roles to wire roles', () => {
+        const body = buildChatCompletionsBody({
+            turns: [
+                { role: Role.System, content: 's' },
+                { role: Role.Assistant, content: 'a' },
+                { role: Role.ToolCall, content: 'tc' },
+                { role: Role.ToolResult, content: 'tr' },
+            ],
+            tier: 'auto', enableReasoning: false, encrypted: false,
+        });
+        expect(body.messages.map((m) => m.role)).toEqual(['system', 'assistant', 'lumo_tool_call', 'tool']);
+    });
+});

--- a/tests/unit/v2-stream.test.ts
+++ b/tests/unit/v2-stream.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { V2StreamProcessor, type V2StreamMessage } from '../../src/lumo-client/v2-stream.js';
+
+/** Feed whole input then finalize, returning all emitted messages. */
+function run(input: string): V2StreamMessage[] {
+    const p = new V2StreamProcessor();
+    return [...p.processChunk(input), ...p.finalize()];
+}
+
+const chunk = (delta: object) =>
+    `data:${JSON.stringify({ object: 'CompletionChunk', model: 'lumo-max', choices: [{ index: 0, delta }] })}\n`;
+
+describe('V2StreamProcessor', () => {
+    it('parses content deltas into message token_data', () => {
+        const msgs = run(chunk({ content: 'pong' }));
+        expect(msgs).toContainEqual({ type: 'token_data', target: 'message', content: 'pong', encrypted: undefined });
+    });
+
+    it('maps reasoning_content and reasoning to the reasoning target', () => {
+        expect(run(chunk({ reasoning_content: 'think' }))).toContainEqual(
+            { type: 'token_data', target: 'reasoning', content: 'think', encrypted: undefined });
+        expect(run(chunk({ reasoning: 'ponder' }))).toContainEqual(
+            { type: 'token_data', target: 'reasoning', content: 'ponder', encrypted: undefined });
+    });
+
+    it('carries the encrypted flag', () => {
+        const msgs = run(chunk({ content: 'X', encrypted: true }));
+        expect(msgs).toContainEqual({ type: 'token_data', target: 'message', content: 'X', encrypted: true });
+    });
+
+    it('reassembles a line split across chunk boundaries', () => {
+        const line = chunk({ content: 'hello' });
+        const p = new V2StreamProcessor();
+        const out = [
+            ...p.processChunk(line.slice(0, 20)),
+            ...p.processChunk(line.slice(20)),
+            ...p.finalize(),
+        ];
+        expect(out).toContainEqual({ type: 'token_data', target: 'message', content: 'hello', encrypted: undefined });
+    });
+
+    it('tolerates CRLF line endings', () => {
+        const line = chunk({ content: 'crlf' }).replace('\n', '\r\n');
+        expect(run(line)).toContainEqual({ type: 'token_data', target: 'message', content: 'crlf', encrypted: undefined });
+    });
+
+    it('emits done on [DONE]', () => {
+        expect(run('data: [DONE]\n')).toEqual([{ type: 'done' }]);
+    });
+
+    it('ignores malformed JSON and SSE comments', () => {
+        expect(run(': keep-alive\ndata: {not json}\n')).toEqual([]);
+    });
+
+    it('emits usage, including after a finish_reason chunk', () => {
+        const finish = `data:${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })}\n`;
+        const usage = `data:${JSON.stringify({ choices: [], usage: { completion_tokens: 2, applied_limit_category: 'max' } })}\n`;
+        const msgs = run(finish + usage);
+        expect(msgs).toContainEqual({ type: 'usage', usage: { completion_tokens: 2, applied_limit_category: 'max' } });
+    });
+
+    it('maps content_filter finish_reason to harmful', () => {
+        const line = `data:${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'content_filter' }] })}\n`;
+        expect(run(line)).toContainEqual({ type: 'harmful' });
+    });
+
+    it('surfaces top-level errors', () => {
+        const line = `data:${JSON.stringify({ error: { code: 'CONTEXT_LENGTH_EXCEEDED', message: 'too long' } })}\n`;
+        expect(run(line)).toContainEqual({ type: 'error', message: 'too long' });
+    });
+
+    it('normalizes chat.tool_call and chat.tool_result objects', () => {
+        const call = `data:${JSON.stringify({ object: 'chat.tool_call', tool_call: { id: 'c1', name: 'proton_info', arguments: '{}', encrypted: true } })}\n`;
+        const result = `data:${JSON.stringify({ object: 'chat.tool_result', tool_result: { call_id: 'c1', content: 'RES', encrypted: true } })}\n`;
+        const msgs = run(call + result);
+        expect(msgs).toContainEqual({ type: 'server_tool_call', call_id: 'c1', name: 'proton_info', arguments: '{}', encrypted: true });
+        expect(msgs).toContainEqual({ type: 'server_tool_result', call_id: 'c1', content: 'RES', encrypted: true });
+    });
+
+    it('accumulates streamed tool_call deltas into one JSON tool_call', () => {
+        const c1 = chunk({ tool_calls: [{ index: 0, function: { name: 'web_search' } }] });
+        const c2 = chunk({ tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] });
+        const c3 = chunk({ tool_calls: [{ index: 0, function: { arguments: '"cats"}' } }] });
+        const msgs = run(c1 + c2 + c3);
+        const toolCalls = msgs.filter((m) => m.type === 'token_data' && m.target === 'tool_call');
+        const last = toolCalls[toolCalls.length - 1];
+        expect(last).toEqual({ type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: 'web_search', arguments: { q: 'cats' } }) });
+    });
+
+    it('ignores image_data objects', () => {
+        const line = `data:${JSON.stringify({ object: 'lumo.image_data', image: { id: 'i', data: 'x' } })}\n`;
+        expect(run(line)).toEqual([]);
+    });
+});

--- a/tests/unit/v2-stream.test.ts
+++ b/tests/unit/v2-stream.test.ts
@@ -87,6 +87,32 @@ describe('V2StreamProcessor', () => {
         expect(last).toEqual({ type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: 'web_search', arguments: { q: 'cats' } }) });
     });
 
+    it('routes content with an explicit reasoning target to reasoning', () => {
+        const line = `data:${JSON.stringify({ choices: [{ delta: { target: 'reasoning', content: 'secret' } }] })}\n`;
+        expect(run(line)).toContainEqual({ type: 'token_data', target: 'reasoning', content: 'secret', encrypted: undefined });
+    });
+
+    it('honors a top-level chunk target', () => {
+        const line = `data:${JSON.stringify({ target: 'reasoning', choices: [{ delta: { content: 't' } }] })}\n`;
+        expect(run(line)).toContainEqual({ type: 'token_data', target: 'reasoning', content: 't', encrypted: undefined });
+    });
+
+    it('copies the top-level model into the usage message', () => {
+        const line = `data:${JSON.stringify({ model: 'lumo-max', choices: [], usage: { completion_tokens: 1 } })}\n`;
+        expect(run(line)).toContainEqual({ type: 'usage', usage: { completion_tokens: 1, model: 'lumo-max' } });
+    });
+
+    it('emits a single complete tool_call only at finalize (not mid-stream)', () => {
+        const p = new V2StreamProcessor();
+        const during = [
+            ...p.processChunk(chunk({ tool_calls: [{ index: 0, function: { name: 'web_search' } }] })),
+            ...p.processChunk(chunk({ tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }] })),
+        ];
+        expect(during.filter((m) => m.type === 'token_data' && m.target === 'tool_call')).toHaveLength(0);
+        const fin = p.finalize();
+        expect(fin).toContainEqual({ type: 'token_data', target: 'tool_call', content: JSON.stringify({ name: 'web_search', arguments: { q: 'x' } }) });
+    });
+
     it('ignores image_data objects', () => {
         const line = `data:${JSON.stringify({ object: 'lumo.image_data', image: { id: 'i', data: 'x' } })}\n`;
         expect(run(line)).toEqual([]);


### PR DESCRIPTION
## Lumo 2.0: model tiers (Lite/Max) + thinking mode

Migrates the upstream client from the legacy `ai/v1/chat` (`generation_request` + `{Prompt}` wrapper) to Proton's current unified **`ai/v1/chat/completions`** endpoint, and exposes the two Lumo 2.0 controls through the OpenAI API:

- **Model tier** via the `model` field: `lumo` (Proton auto-routes), `lumo-lite`, `lumo-max`. Advertised on `/v1/models`; unknown models return HTTP 400.
- **Thinking mode** via `reasoning_effort` (chat) / `reasoning.effort` (responses): `high`/`low`/`medium` enable it, `none` disables it. Optionally surfaced to clients as `reasoning_content`.

End-to-end U2L encryption is preserved (the existing crypto primitives are reused unchanged; only the request packaging and SSE parsing differ). No re-vendoring of `packages/lumo` was required.

### What changed
- New `src/lumo-client/v2-body.ts` (chat/completions body builder) and `v2-stream.ts` (OpenAI-SSE parser: content/reasoning/tool-calls/native tools/usage, tolerant of chunk boundaries/CRLF/`[DONE]`).
- `client.ts` rewritten to POST the v2 body, decrypt content + reasoning, drain reasoning to a sink (never merged into the answer), feed native + `server_tool_*` calls into the existing processor, keep custom-tool bounce, and generate titles via a separate concurrent `lumo.target:'title'` completion.
- Transport (`api-factory.ts`) preserves the full Proton error body (`data`/`body`) so terminal errors are decodable.
- Inbound wiring across `/v1/chat/completions` and `/v1/responses`: `model`→tier, `reasoning_effort`→thinking, runtime validation (bad model/effort → 400 before side effects), `/v1/models` lists the tiers.
- Config (`config.defaults.yaml` + zod): `defaultModelTier`, `allowedModels`, `reasoning.{default,surfaceThinking}`. Config arrays now replace instead of index-merge so `allowedModels` can be narrowed. Existing `config.yaml` files remain valid (defaults merged in).
- README section; mock updated to emit the v2 SSE so tests exercise the real path.

### Testing
- 421 unit + integration tests pass (`npm test`), including new coverage for the body builder, SSE parser, model/effort mapping + validation, and client lifecycle (reasoning drain, full tool-call args, separate title, bounce-with-title, usage).
- Verified live against Proton on a paid account: encrypted round-trip decrypts; `lumo-lite` vs `lumo-max` bill the matching `usage.applied_limit_category`; `reasoning_effort:high` streams reasoning; unknown model + bad effort return 400.

### Notes / scoped out (follow-ups)
- Responses-API reasoning is threaded but not surfaced as `type:"reasoning"` output items (Chat Completions uses the `reasoning_content` extension).
- Image generation and `suggested_questions` are not surfaced.
- `x-pm-appversion` is left at the existing value (the new endpoint accepted it in testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
