### PR TITLE
fix(app): register fallback store in mock mode

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -52,7 +52,7 @@ export class Application {
       setConversationStore(result.conversationStore);
     } else {
       // Use fallback in-memory store
-      getFallbackStore();
+      setConversationStore(getFallbackStore());
     }
 
     this.protonApi = createMockProtonApi(mockConfig.scenario);


### PR DESCRIPTION
## Summary

Mock mode crashes on startup when `conversations.useFallbackStore` is `true` (the default).

In `Application.initializeMock()`, the `useFallbackStore` else-branch called `getFallbackStore()` but never registered it as the active conversation store:

```ts
} else {
  // Use fallback in-memory store
  getFallbackStore();   // <-- never registered
}
```

This left the `activeStore` singleton `null`, so `APIServer.getDependencies()` → `getConversationStore()` threw on boot:

```
Error: ConversationStore not initialized - call initializeConversationStore() first
    at getConversationStore (src/conversations/index.ts:215)
    at Application.getConversationStore (src/app/index.ts:122)
    at APIServer.getDependencies (src/api/server.ts:58)
    ...
```

The container then crash-looped (`restart: unless-stopped`) and `/health` never came up.

## Fix

Wrap the call in `setConversationStore()`, mirroring the primary-store branch immediately above:

```ts
} else {
  // Use fallback in-memory store
  setConversationStore(getFallbackStore());
}
```

`setConversationStore` is already imported and used by the `!useFallbackStore` branch, so this is consistent with the existing pattern.

## Testing

- Without the fix: `tamer server` with `test.mock.enabled: true` and default config → fatal `ConversationStore not initialized`, crash loop, `/health` unreachable.
- With the fix: server reports `Mock mode active - auth and sync bypassed` then `lumo-tamer is ready!`; `/health`, `/v1/models`, and `/v1/chat/completions` all respond correctly with mocked responses.

Built and verified against the current `main` (Docker image, Node 22 + Go 1.24).
