### PR TITLE
Fix Windows path handling, Lumo 2.0 CDP re-auth, and surface auth health on /health

### DIFF
--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -5,12 +5,16 @@ export function createHealthRouter(deps: EndpointDependencies): Router {
   const router = Router();
 
   router.get('/health', (req: Request, res: Response) => {
+    const authManager = deps.authManager;
+    const auth = authManager?.getHealth?.() ?? { available: false };
+
     res.json({
       status: 'ok',
       queue: {
         size: deps.queue.getSize(),
-        pending: deps.queue.getPending()
-      }
+        pending: deps.queue.getPending(),
+      },
+      auth,
     });
   });
 

--- a/src/app/paths.ts
+++ b/src/app/paths.ts
@@ -11,9 +11,10 @@ import { dirname, join, isAbsolute } from 'path';
 // Detect project root based on runtime location:
 // - tsx runs from src/app/paths.ts (2 levels up)
 // - node runs from dist/src/app/paths.js (3 levels up)
+// Match /dist/ and \dist\ — Windows path.sep is \, so a /dist/-only check fails there.
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const isCompiledDist = __dirname.includes('/dist/');
+const isCompiledDist = /(?:^|[\\/])dist[\\/]/.test(__dirname);
 export const PROJECT_ROOT = isCompiledDist
     ? join(__dirname, '..', '..', '..')
     : join(__dirname, '..', '..');
@@ -24,7 +25,8 @@ export const PROJECT_ROOT = isCompiledDist
 export function resolveProjectPath(path: string): string {
   if (isAbsolute(path)) return path;
   if (path.startsWith('~')) {
-    return path.replace('~', process.env.HOME || '');
+    const home = process.env.HOME || process.env.USERPROFILE || '';
+    return path.replace('~', home);
   }
   return join(PROJECT_ROOT, path);
 }

--- a/src/auth/browser/authenticate.ts
+++ b/src/auth/browser/authenticate.ts
@@ -361,8 +361,15 @@ async function connectAndGetPage(
 
     logger.info({ pageCount: pages.length }, 'Found pages in browser context');
 
-    // Check if already on Lumo
-    let page = pages.find(p => p.url().includes('lumo.proton.me'));
+    // Prefer an already-logged-in Lumo tab (Lumo 2.0 uses /u/<n>/… paths).
+    const isLumoLoggedIn = (url: string) =>
+        /lumo\.proton\.me/i.test(url) &&
+        !/\/guest/i.test(url) &&
+        !/account\.proton/i.test(url);
+
+    let page =
+        pages.find(p => isLumoLoggedIn(p.url())) ||
+        pages.find(p => p.url().includes('lumo.proton.me'));
 
     if (!page) {
         logger.info({ targetUrl }, 'No Lumo page found, navigating...');
@@ -373,16 +380,31 @@ async function connectAndGetPage(
     const currentUrl = page.url();
     logger.info({ currentUrl }, 'Current URL');
 
-    // Check if logged in
-    if (currentUrl.includes('account.proton') || currentUrl.includes('/login')) {
+    // Check if logged in (account host, login path, or Lumo guest landing)
+    const needsLogin =
+        currentUrl.includes('account.proton') ||
+        currentUrl.includes('/login') ||
+        /lumo\.proton\.me\/guest/i.test(currentUrl);
+
+    if (needsLogin) {
         logger.warn('Not logged in. Please log in manually in the browser.');
         logger.info('Waiting for login...');
 
         try {
-            await page.waitForURL(/lumo\.proton\.me\/(chat|c\/|$)/, { timeout: loginTimeout });
-            logger.info('Login detected!');
+            // Lumo 1.x: /chat, /c/…  |  Lumo 2.0: /u/<id>/…
+            await page.waitForURL(
+                /lumo\.proton\.me\/(u\/|chat|c\/|$)/,
+                { timeout: loginTimeout }
+            );
+            if (/\/guest/i.test(page.url())) {
+                await page.waitForURL(
+                    /lumo\.proton\.me\/u\//,
+                    { timeout: loginTimeout }
+                );
+            }
+            logger.info({ url: page.url() }, 'Login detected!');
         } catch {
-            await browser.close();
+            // Avoid browser.close() on CDP — it can tear down the debug session.
             throw new Error('Login timeout. Please log in and try again.');
         }
     }

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -36,6 +36,8 @@ export class AuthManager {
     private refreshTimer?: NodeJS.Timeout;
     private protonApi?: ProtonApiWithRefresh;
     private isRefreshing = false;
+    private lastRefreshFailure: { at: string; error: string } | null = null;
+    private consecutiveFailures = 0;
 
     constructor(options: AuthManagerOptions) {
         this.provider = options.provider;
@@ -93,8 +95,13 @@ export class AuthManager {
         this.refreshTimer = setInterval(async () => {
             try {
                 await this.refreshNow();
+                this.lastRefreshFailure = null;
+                this.consecutiveFailures = 0;
             } catch (error) {
-                logger.error({ error }, 'Scheduled token refresh failed');
+                const message = error instanceof Error ? error.message : String(error);
+                this.lastRefreshFailure = { at: new Date().toISOString(), error: message };
+                this.consecutiveFailures++;
+                logger.error({ error, consecutiveFailures: this.consecutiveFailures }, 'Scheduled token refresh failed');
             }
         }, intervalMs);
 
@@ -159,9 +166,28 @@ export class AuthManager {
                 accessToken: this.getAccessToken(),
             };
         } catch (error) {
-            logger.error({ error }, 'Failed to refresh tokens after 401');
+            const message = error instanceof Error ? error.message : String(error);
+            this.lastRefreshFailure = { at: new Date().toISOString(), error: message };
+            this.consecutiveFailures++;
+            logger.error({ error, consecutiveFailures: this.consecutiveFailures }, 'Failed to refresh tokens after 401');
             return null;
         }
+    }
+
+    /**
+     * Return combined health info for the /health endpoint.
+     */
+    getHealth() {
+        const status = this.provider.getStatus();
+        return {
+            available: true,
+            method: status.method,
+            valid: status.valid,
+            details: status.details,
+            warnings: status.warnings,
+            lastRefreshFailure: this.lastRefreshFailure,
+            consecutiveFailures: this.consecutiveFailures,
+        };
     }
 
     /**


### PR DESCRIPTION
## What

- paths.ts: isCompiledDist only matched forward slashes (/dist/), so a compiled build running on Windows (path.sep is \) resolved the wrong project root. Now matches both separators, and falls back to USERPROFILE when HOME isn't set.
- auth/browser/authenticate.ts: recognizes Lumo 2.0's /u/<id>/ URL scheme and guest-landing state when detecting whether a CDP-attached browser is logged in - the previous regex only matched the old /chat and /c/ paths. Also stops closing the CDP browser connection on a login timeout; closing it tore down the whole debug session instead of just failing that one attempt.
- auth/manager.ts: tracks the last refresh failure and a consecutive-failure count, exposed through a new getHealth() method.
- api/routes/health.ts: surfaces that auth status on GET /health.

## Why

Running this under a process supervisor that polls /health and attempts CDP-based re-authentication on Windows surfaced all four issues together: compiled-dist detection silently resolved to the wrong root, Lumo 2.0's UI changes broke login detection during automated re-auth, and /health gave no signal when token refresh was failing versus succeeding.

## Testing

Verified locally on Windows against the compiled dist build, through several real auth-expiry and recovery cycles (expired token, detected failure, CDP re-auth, healthy).